### PR TITLE
Cluster frontend

### DIFF
--- a/bims/api_views/cluster.py
+++ b/bims/api_views/cluster.py
@@ -21,5 +21,9 @@ class ClusterList(APIView):
 
         boundaries = Boundary.objects.filter(
             type=boundary_type)
-        serializer = BoundarySerializer(boundaries, many=True)
+        clean_boundaries = []
+        for boundary in boundaries:
+            if boundary.cluster_set.filter(site_count__gte=1).count() >= 1:
+                clean_boundaries.append(boundary)
+        serializer = BoundarySerializer(clean_boundaries, many=True)
         return Response(serializer.data)

--- a/bims/api_views/cluster_collection_by_taxon.py
+++ b/bims/api_views/cluster_collection_by_taxon.py
@@ -121,4 +121,4 @@ class ClusterCollectionByTaxon(APIView):
         cluster = self.clustering_process(
             queryset, int(zoom), int(icon_pixel_x), int(icon_pixel_y)
         )
-        return Response(geo_serializer(cluster))
+        return Response(geo_serializer(cluster)['features'])

--- a/bims/api_views/location_site.py
+++ b/bims/api_views/location_site.py
@@ -1,4 +1,6 @@
 # coding=utf8
+from django.contrib.gis.geos import Polygon
+from django.db.models import Q
 from django.http import Http404
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -12,8 +14,20 @@ class LocationSiteList(APIView):
     """
     List all location site
     """
+
     def get(self, request, *args):
         location_site = LocationSite.objects.all()
+        # get by bbox
+        bbox = request.GET.get('bbox', None)
+        if bbox:
+            geom_bbox = Polygon.from_bbox(
+                tuple([float(edge) for edge in bbox.split(',')]))
+            location_site = location_site.filter(
+                Q(geometry_point__intersects=geom_bbox) |
+                Q(geometry_line__intersects=geom_bbox) |
+                Q(geometry_polygon__intersects=geom_bbox) |
+                Q(geometry_multipolygon__intersects=geom_bbox)
+            )
         serializer = LocationSiteSerializer(location_site, many=True)
         return Response(serializer.data)
 
@@ -22,6 +36,7 @@ class LocationSiteDetail(APIView):
     """
     Return detail of location site
     """
+
     def get_object(self, pk):
         try:
             return LocationSite.objects.get(pk=pk)

--- a/bims/serializers/bio_collection_record_doc_serializer.py
+++ b/bims/serializers/bio_collection_record_doc_serializer.py
@@ -22,5 +22,6 @@ class BiologicalCollectionRecordDocSerializer(serializers.ModelSerializer):
             'collector',
             'category',
             'collection_date',
-            'geometry'
+            'geometry',
+            'taxon_gbif_id'
         ]

--- a/bims/serializers/boundary_serializer.py
+++ b/bims/serializers/boundary_serializer.py
@@ -9,6 +9,7 @@ class BoundarySerializer(serializers.ModelSerializer):
     Serializer for boundary model.
     """
     cluster_data = serializers.SerializerMethodField()
+    boundary_type = serializers.SerializerMethodField()
     point = serializers.SerializerMethodField()
 
     def get_cluster_data(self, obj):
@@ -21,6 +22,9 @@ class BoundarySerializer(serializers.ModelSerializer):
     def get_point(self, obj):
         center = obj.geometry.centroid
         return [center.x, center.y]
+
+    def get_boundary_type(self, obj):
+        return obj.type.name
 
     class Meta:
         model = Boundary

--- a/bims/static/css/map.css
+++ b/bims/static/css/map.css
@@ -69,9 +69,9 @@ html, body, .map, .map-wrapper, #map-container {
     background: rgba(255, 255, 255, 1);
     color: #4e4e4e;
     z-index: 2000;
-    -webkit-box-shadow: 3px 3px 5px 6px rgba(0, 0, 0, 0.3);  /* Safari 3-4, iOS 4.0.2 - 4.2, Android 2.3+ */
-    -moz-box-shadow:    3px 3px 5px 6px rgba(0, 0, 0, 0.3);  /* Firefox 3.5 - 3.6 */
-    box-shadow:         3px 3px 5px 6px rgba(0, 0, 0, 0.3);  /* Opera 10.5, IE 9, Firefox 4+, Chrome 6+, iOS 5 */
+    -webkit-box-shadow: 3px 3px 5px 6px rgba(0, 0, 0, 0.3); /* Safari 3-4, iOS 4.0.2 - 4.2, Android 2.3+ */
+    -moz-box-shadow: 3px 3px 5px 6px rgba(0, 0, 0, 0.3); /* Firefox 3.5 - 3.6 */
+    box-shadow: 3px 3px 5px 6px rgba(0, 0, 0, 0.3); /* Opera 10.5, IE 9, Firefox 4+, Chrome 6+, iOS 5 */
 
 }
 
@@ -431,4 +431,21 @@ div:hover::-webkit-scrollbar {
 
 .search-results-total:hover {
     cursor: pointer;
+}
+
+#loading-warning {
+    position: absolute;
+    padding: 10px;
+    top: 10px;
+    width: 100%;
+    text-align: center;
+    opacity: 0.3;
+}
+
+#loading-warning span {
+    background-color: grey;
+    color: white;
+    padding: 10px;
+    padding-left: 20px;
+    padding-right: 20px;
 }

--- a/bims/static/js/collections/cluster.js
+++ b/bims/static/js/collections/cluster.js
@@ -4,7 +4,7 @@ define(['backbone', 'models/cluster', 'views/cluster'], function (Backbone, Clus
         clusterAPI: "/api/cluster/",
         url: "",
         viewCollection: [],
-        updateAdministrative: function (administrative) {
+        updateUrl: function (administrative) {
             this.administrative = administrative;
             this.url = this.clusterAPI + administrative
         },

--- a/bims/static/js/collections/cluster_biological.js
+++ b/bims/static/js/collections/cluster_biological.js
@@ -1,0 +1,43 @@
+define(['backbone', 'models/cluster_biological', 'views/cluster_biological', 'shared'], function (Backbone, ClusterModel, ClusterView, Shared) {
+    return Backbone.Collection.extend({
+        model: ClusterModel,
+        clusterAPI: _.template("/api/cluster/collection/taxon/<%= taxonID %>/?icon_pixel_x=30&icon_pixel_y=30&zoom=<%= zoom %>&bbox=<%= bbox %>"),
+        url: "",
+        viewCollection: [],
+        initialize: function (options) {
+            Shared.Dispatcher.on('searchResult:clicked', this.updateTaxon, this);
+        },
+        updateTaxon: function (taxonID) {
+            this.taxonID = taxonID;
+            this.refresh();
+        },
+        updateZoomAndBBox: function (zoom, bbox) {
+            this.zoom = zoom;
+            this.bbox = bbox;
+            this.refresh();
+        },
+        refresh: function () {
+            if (this.taxonID && this.zoom && this.bbox) {
+                this.url = this.clusterAPI(
+                    {
+                        taxonID: this.taxonID,
+                        zoom: this.zoom,
+                        bbox: this.bbox
+                    }
+                );
+            }
+        },
+        renderCollection: function () {
+            var self = this;
+            $.each(this.viewCollection, function (index, view) {
+                view.destroy();
+            });
+            this.viewCollection = [];
+            $.each(this.models, function (index, model) {
+                self.viewCollection.push(new ClusterView({
+                    model: model
+                }));
+            });
+        }
+    })
+});

--- a/bims/static/js/collections/cluster_biological.js
+++ b/bims/static/js/collections/cluster_biological.js
@@ -4,9 +4,6 @@ define(['backbone', 'models/cluster_biological', 'views/cluster_biological', 'sh
         clusterAPI: _.template("/api/cluster/collection/taxon/<%= taxonID %>/?icon_pixel_x=30&icon_pixel_y=30&zoom=<%= zoom %>&bbox=<%= bbox %>"),
         url: "",
         viewCollection: [],
-        initialize: function (options) {
-            Shared.Dispatcher.on('searchResult:clicked', this.updateTaxon, this);
-        },
         updateTaxon: function (taxonID) {
             this.taxonID = taxonID;
             this.refresh();

--- a/bims/static/js/collections/location_site.js
+++ b/bims/static/js/collections/location_site.js
@@ -1,8 +1,12 @@
 define(['backbone', 'models/location_site', 'views/location_site'], function (Backbone, LocationSiteModel, LocationSiteView) {
     return Backbone.Collection.extend({
         model: LocationSiteModel,
-        url: "/api/location-site/",
+        collectionAPI: "/api/location-site/?bbox=",
+        url: "",
         viewCollection: [],
+        updateUrl: function (bbox) {
+            this.url = this.collectionAPI + bbox
+        },
         renderCollection: function () {
             var self = this;
             $.each(this.viewCollection, function (index, view) {

--- a/bims/static/js/models/cluster_biological.js
+++ b/bims/static/js/models/cluster_biological.js
@@ -1,0 +1,8 @@
+define(['backbone'], function (Backbone) {
+    return Backbone.Model.extend({
+        destroy: function () {
+            this.unbind();
+            delete this;
+        }
+    })
+});

--- a/bims/static/js/views/cluster.js
+++ b/bims/static/js/views/cluster.js
@@ -15,6 +15,20 @@ define(['backbone', 'models/cluster', 'ol', 'shared'], function (Backbone, Clust
             var geometry = modelJson['point'];
             delete modelJson['geometry'];
             modelJson['text'] = modelJson['name'];
+
+            // assign count
+            var count = 0;
+            try {
+                count = modelJson['cluster_data']['location site']['details']['records'];
+            }
+            catch (err) {
+            }
+
+            if (count === 0) {
+                return
+            }
+
+            modelJson['count'] = count;
             var geojson = {
                 "type": "Feature",
                 "geometry": {
@@ -27,7 +41,7 @@ define(['backbone', 'models/cluster', 'ol', 'shared'], function (Backbone, Clust
             this.features = new ol.format.GeoJSON().readFeatures(geojson, {
                 featureProjection: 'EPSG:3857'
             });
-            Shared.Dispatcher.trigger('map:addLocationSiteFeatures', this.features)
+            Shared.Dispatcher.trigger('map:addClusterFeatures', this.features)
         },
         destroy: function () {
             this.unbind();

--- a/bims/static/js/views/cluster_biological.js
+++ b/bims/static/js/views/cluster_biological.js
@@ -1,0 +1,20 @@
+define(['backbone', 'models/cluster_biological', 'ol', 'shared'], function (Backbone, Cluster, ol, Shared) {
+    return Backbone.View.extend({
+        initialize: function (options) {
+            this.render();
+        },
+        render: function () {
+            var modelJson = this.model.toJSON();
+            this.id = modelJson['id'];
+            this.features = new ol.format.GeoJSON().readFeatures(modelJson, {
+                featureProjection: 'EPSG:3857'
+            });
+            Shared.Dispatcher.trigger('map:addClusterFeatures', this.features)
+        },
+        destroy: function () {
+            this.unbind();
+            this.model.destroy();
+            return Backbone.View.prototype.remove.call(this);
+        }
+    })
+});

--- a/bims/static/js/views/cluster_biological.js
+++ b/bims/static/js/views/cluster_biological.js
@@ -9,7 +9,7 @@ define(['backbone', 'models/cluster_biological', 'ol', 'shared'], function (Back
             this.features = new ol.format.GeoJSON().readFeatures(modelJson, {
                 featureProjection: 'EPSG:3857'
             });
-            Shared.Dispatcher.trigger('map:addClusterFeatures', this.features)
+            Shared.Dispatcher.trigger('map:addClusterFeatures', this.features, true)
         },
         destroy: function () {
             this.unbind();

--- a/bims/static/js/views/olmap.js
+++ b/bims/static/js/views/olmap.js
@@ -375,6 +375,9 @@ define([
             if (!this.sidePanelView.isSidePanelOpen()) {
                 return
             }
+            if (!taxonID && !this.clusterBiologicalCollection.taxonID) {
+                return
+            }
             this.clusterBiologicalCollection.updateTaxon(taxonID);
             if (!this.clusterBiologicalCollection.taxonID) {
                 // clear all data for taxon records

--- a/bims/static/js/views/search_result.js
+++ b/bims/static/js/views/search_result.js
@@ -10,11 +10,7 @@ define(['backbone', 'models/search_result', 'shared', 'underscore', 'ol'], funct
             this.render();
         },
         clicked: function (e) {
-            var geometry = JSON.parse(this.model.attributes['geometry']);
-            var coordinates = ol.proj.transform(geometry['coordinates'], "EPSG:4326", "EPSG:3857");
-            var zoomLevel = 15;
             Shared.Dispatcher.trigger('searchResult:clicked', this.model.get('taxon_gbif_id'));
-            Shared.Dispatcher.trigger('map:zoomToCoordinates', coordinates, zoomLevel);
         },
         render: function () {
             this.data = this.model.toJSON();

--- a/bims/static/js/views/search_result.js
+++ b/bims/static/js/views/search_result.js
@@ -13,6 +13,7 @@ define(['backbone', 'models/search_result', 'shared', 'underscore', 'ol'], funct
             var geometry = JSON.parse(this.model.attributes['geometry']);
             var coordinates = ol.proj.transform(geometry['coordinates'], "EPSG:4326", "EPSG:3857");
             var zoomLevel = 15;
+            Shared.Dispatcher.trigger('searchResult:clicked', this.model.get('taxon_gbif_id'));
             Shared.Dispatcher.trigger('map:zoomToCoordinates', coordinates, zoomLevel);
         },
         render: function () {

--- a/bims/static/js/views/side_panel.js
+++ b/bims/static/js/views/side_panel.js
@@ -24,6 +24,9 @@ define(['shared', 'backbone', 'underscore', 'jqueryUi'], function(Shared, Backbo
 
             return this;
         },
+        isSidePanelOpen:function () {
+          return this.rightPanel.is(":visible");
+        },
         openSidePanel: function (properties) {
             this.rightPanel.show('slide', { direction: 'right'}, 200);
             if(typeof properties !== 'undefined') {
@@ -68,11 +71,11 @@ define(['shared', 'backbone', 'underscore', 'jqueryUi'], function(Shared, Backbo
             $rightPanelTitle.html(title);
         },
         closeSidePanel: function (e) {
+            Shared.Dispatcher.trigger('searchResult:clicked', null);
             var self = this;
             this.rightPanel.hide('slide', { direction: 'right'}, 200, function () {
                 self.clearSidePanel();
             });
-            Shared.Dispatcher.trigger('searchResult:clicked', null);
         },
         fillSidePanel: function (contents) {
             for (var key in contents) {

--- a/bims/static/js/views/side_panel.js
+++ b/bims/static/js/views/side_panel.js
@@ -72,6 +72,7 @@ define(['shared', 'backbone', 'underscore', 'jqueryUi'], function(Shared, Backbo
             this.rightPanel.hide('slide', { direction: 'right'}, 200, function () {
                 self.clearSidePanel();
             });
+            Shared.Dispatcher.trigger('searchResult:clicked', null);
         },
         fillSidePanel: function (contents) {
             for (var key in contents) {

--- a/bims/templates/map.html
+++ b/bims/templates/map.html
@@ -23,6 +23,7 @@
 
 {% block body_content %}
     <div id="map-container"></div>
+    <div id="loading-warning"><span>LOADING....</span></div>
 
     <script type='text/html' id='map-template'>
         <div id="map" class="map"></div>

--- a/bims/tests/test_cluster_collection_by_taxon_views.py
+++ b/bims/tests/test_cluster_collection_by_taxon_views.py
@@ -62,7 +62,7 @@ class TestApiView(TestCase):
                 'zoom': 1
             })
         response = view(request, 1)
-        features = response.data['features']
+        features = response.data
         self.assertEqual(
             len(features), 1)
         self.assertEqual(
@@ -76,7 +76,7 @@ class TestApiView(TestCase):
                 'zoom': 1
             })
         response = view(request, 1)
-        features = response.data['features']
+        features = response.data
         self.assertEqual(
             len(features), 1)
         self.assertEqual(
@@ -93,7 +93,7 @@ class TestApiView(TestCase):
                 'zoom': 18
             })
         response = view(request, 1)
-        features = response.data['features']
+        features = response.data
         self.assertEqual(
             len(features), 2)
         for feature in features:
@@ -108,7 +108,7 @@ class TestApiView(TestCase):
                 'zoom': 18
             })
         response = view(request, 2)
-        features = response.data['features']
+        features = response.data
         self.assertEqual(
             len(features), 1)
         for feature in features:
@@ -123,6 +123,6 @@ class TestApiView(TestCase):
                 'zoom': 18
             })
         response = view(request, 2)
-        features = response.data['features']
+        features = response.data
         self.assertEqual(
             len(features), 0)

--- a/bims/urls.py
+++ b/bims/urls.py
@@ -15,7 +15,8 @@ from bims.api_views.location_type import (
 from bims.api_views.taxon import TaxonDetail
 from bims.api_views.cluster import ClusterList
 from bims.api_views.cluster_collection_by_taxon import (
-    ClusterCollectionByTaxon
+    ClusterCollectionByTaxon,
+    ClusterCollectionByTaxonExtent
 )
 from bims.views.links import LinksCategoryView
 from bims.api_views.search import SearchObjects
@@ -32,6 +33,8 @@ api_urls = [
         TaxonDetail.as_view()),
     url(r'^api/cluster/(?P<administrative_level>\w+)/$',
         ClusterList.as_view()),
+    url(r'^api/cluster/collection/taxon/(?P<pk>[0-9]+)/extent/$',
+        ClusterCollectionByTaxonExtent.as_view()),
     url(r'^api/cluster/collection/taxon/(?P<pk>[0-9]+)/$',
         ClusterCollectionByTaxon.as_view()),
     url(r'^api/search/(?P<query_value>\w+)/$',


### PR DESCRIPTION
this fix #https://github.com/kartoza/LEDET_BIMS/issues/119

This fix showing cluster in bubble style
and also showing cluster of species in bubble too

![selection_055](https://user-images.githubusercontent.com/4530905/41712775-95d78d26-7575-11e8-9298-448243745337.png)

check one species:
![selection_056](https://user-images.githubusercontent.com/4530905/41712778-977ae420-7575-11e8-9309-d51c8be3bdcb.png)
![selection_057](https://user-images.githubusercontent.com/4530905/41712780-993054bc-7575-11e8-9540-616de0c7bdfa.png)


DEMO : 
https://drive.google.com/file/d/1mkePHq2dQj2PB4nifSSK1mtH7O-cNUxK/view?usp=sharing

TODO:
- [ ] Show indicator of what taxonomy we are looking now.
- [ ] For 1 bubble, show details of that records
- [ ] Colouring is still hardcoded. 0-10 records -> red, 10-100 -> yellow, <100 green