### PR TITLE
not call fetching collection if the layer is turned off

### DIFF
--- a/bims/static/js/views/olmap.js
+++ b/bims/static/js/views/olmap.js
@@ -185,7 +185,7 @@ define([
             var basemap = new Basemap();
 
             var center = [22.937506, -30.559482];
-            if(centerPointMap) {
+            if (centerPointMap) {
                 var centerArray = centerPointMap.split(',');
                 for (var i in centerArray) {
                     centerArray[i] = parseFloat(centerArray[i]);
@@ -288,6 +288,11 @@ define([
                     this.boundaryView.renderAdministrativeBoundary(
                         administrative, this.getCurrentBbox());
 
+                    // if layer is shows
+                    if (!this.layers.isBiodiversityLayerShow()) {
+                        return;
+                    }
+
                     this.previousZoom = zoomLevel;
                     this.clusterCollection.updateUrl(administrative);
                     if (this.clusterCollection.getCache()) {
@@ -305,6 +310,10 @@ define([
                         });
                     }
                 } else {
+                    // if layer is shows
+                    if (!this.layers.isBiodiversityLayerShow()) {
+                        return;
+                    }
                     this.previousZoom = -1;
                     this.clusterCollection.administrative = null;
                     this.fetchingReset();
@@ -320,6 +329,10 @@ define([
                     });
                 }
             } else {
+                // if layer is shows
+                if (!this.layers.isBiodiversityLayerShow()) {
+                    return;
+                }
                 this.fetchingReset();
                 this.fetchingStart();
                 this.fetchXhr = this.clusterBiologicalCollection.fetch({

--- a/bims/static/js/views/olmap_layers.js
+++ b/bims/static/js/views/olmap_layers.js
@@ -1,4 +1,4 @@
-define(['backbone', 'underscore', 'jquery', 'ol', 'views/layer_style'], function (Backbone, _, $, ol, LayerStyle) {
+define(['shared', 'backbone', 'underscore', 'jquery', 'ol', 'views/layer_style'], function (Shared, Backbone, _, $, ol, LayerStyle) {
     return Backbone.View.extend({
         nonBiodiversityLayersInitiation: {
             '2012 Vegetation Map of South Africa, Lesotho and Swaziland': new ol.layer.Tile({
@@ -55,6 +55,10 @@ define(['backbone', 'underscore', 'jquery', 'ol', 'views/layer_style'], function
         layers: {},
         initialize: function () {
             this.layerStyle = new LayerStyle();
+        },
+        isBiodiversityLayerShow: function () {
+            var $checkbox = $('.layer-selector-input[value="Biodiversity"]');
+            return $checkbox.is(':checked');
         },
         initLayer: function (layer, layerName, visibleInDefault) {
             this.layers[layerName] = {
@@ -118,6 +122,9 @@ define(['backbone', 'underscore', 'jquery', 'ol', 'views/layer_style'], function
             this.renderLayers();
         },
         selectorChanged: function (layerName, selected) {
+            if (layerName == "Biodiversity") {
+                Shared.Dispatcher.trigger('map:reloadXHR');
+            }
             this.layers[layerName]['layer'].setVisible(selected)
         },
         ol3_checkLayer: function (layer) {


### PR DESCRIPTION
This PR updates:
- Will not call fetching collection function if layer of biodiversity is turned off (so no "loading" message show and map will be panned)