### PR TITLE
update UI

### DIFF
--- a/bims/context_processor.py
+++ b/bims/context_processor.py
@@ -63,4 +63,14 @@ def custom_navbar_url(request):
     except AttributeError:
         context['contributions_url'] = None
 
+    try:
+        context['title_bims_abbr'] = settings.TITLE_BIMS_ABBREVIATION
+    except AttributeError:
+        context['title_bims_abbr'] = None
+
+    try:
+        context['title_bims_long'] = settings.TITLE_BIMS_LONG
+    except AttributeError:
+        context['title_bims_long'] = None
+
     return context

--- a/bims/static/css/map.css
+++ b/bims/static/css/map.css
@@ -464,7 +464,7 @@ html, body, .map, .map-wrapper, #map-container {
 
 .layer-switcher {
     position: absolute;
-    top: 198px !important;
+    top: 190px !important;
     left: 0;
     right: auto !important;
     text-align: left;
@@ -475,10 +475,11 @@ html, body, .map, .map-wrapper, #map-container {
 
 .layer-switcher button {
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
-    width: 41px !important;
+    width: 54px !important;
     height: 41px !important;
-    background-position: 6px !important;
+    background-position: center !important;
     background-size: 32px;
+    margin: 0 auto;
 }
 
 .layer-switcher .panel {
@@ -486,6 +487,11 @@ html, body, .map, .map-wrapper, #map-container {
     border: none !important;
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
     padding: 9px !important;
+    position: absolute;
+    width: 250px;
+    margin-left: 55px !important;
+    background-color: rgba(204, 204, 204, 0.4) !important;
+    border-radius: 0 !important;
 }
 
 .layer-switcher ul {
@@ -495,6 +501,14 @@ html, body, .map, .map-wrapper, #map-container {
 
 .layer-switcher input {
     cursor: pointer;
+}
+
+.layer-switcher.shown button {
+    background-color: #1b900d !important;
+}
+
+.layer-switcher button:focus {
+    outline: none !important;
 }
 
 .result-search {

--- a/bims/static/css/navbar.css
+++ b/bims/static/css/navbar.css
@@ -90,6 +90,14 @@
     font-size: 10pt;
 }
 
+.bims-nav-footer a {
+    font-size: 10pt;
+}
+
+.bims-nav-footer a:hover {
+    color: yellow !important;
+}
+
 .bims-nav-footer img {
     vertical-align: top;
 }

--- a/bims/static/js/libs/ol-layerswitcher/ol-layerswitcher.js
+++ b/bims/static/js/libs/ol-layerswitcher/ol-layerswitcher.js
@@ -138,19 +138,11 @@ var LayerSwitcher = function (_Control) {
 
         var this_ = _this;
 
-        button.onmouseover = function (e) {
-            this_.showPanel();
-        };
-
         button.onclick = function (e) {
-            e = e || window.event;
-            this_.showPanel();
-            e.preventDefault();
-        };
-
-        this_.panel.onmouseout = function (e) {
-            e = e || window.event;
-            if (!this_.panel.contains(e.toElement || e.relatedTarget)) {
+            $('.control-panel-selected').click();
+            if (!$(element).hasClass(_this.shownClassName)) {
+               this_.showPanel();
+            }else {
                 this_.hidePanel();
             }
         };

--- a/bims/static/js/libs/ol-layerswitcher/ol3-layerswitcher.css
+++ b/bims/static/js/libs/ol-layerswitcher/ol3-layerswitcher.css
@@ -43,10 +43,6 @@
     border: none;
 }
 
-.layer-switcher.shown button {
-    display: none;
-}
-
 .layer-switcher button:focus, .layer-switcher button:hover {
     background-color: white;
 }

--- a/bims/static/js/views/map_control_panel.js
+++ b/bims/static/js/views/map_control_panel.js
@@ -16,6 +16,7 @@ define(['backbone', 'underscore', 'jquery', 'ol', 'views/search'], function (Bac
             this.parent = options.parent;
         },
         searchClicked: function (e) {
+            $('.layer-switcher.shown button').click();
             // show search div
             if (!this.searchView.isOpen()) {
                 this.openSearchPanel();
@@ -25,6 +26,7 @@ define(['backbone', 'underscore', 'jquery', 'ol', 'views/search'], function (Bac
             }
         },
         filterClicked: function (e) {
+            $('.layer-switcher.shown button').click();
             // show filter div
             if ($('.layers-selector-container').is(":hidden")) {
                 this.openFilterPanel();

--- a/bims/templates/main_base.html
+++ b/bims/templates/main_base.html
@@ -41,7 +41,7 @@
                         <li><a class="nav-link js-scroll-trigger" id="navbar-contact" href="/contact/">CONTACT</a></li>
                         <li><a class="nav-link js-scroll-trigger" id="navbar-biblio" href="/bibliography/">BIBLIOGRAPHY</a></li>
                         <div class="bims-nav-footer row">
-                            <div class="col-lg-12">MADE WITH <img src="{% static 'img/kartoza-logo-only.png' %}" height="20px"> BY KARTOZA</div>
+                            <div class="col-lg-12">MADE WITH <img src="{% static 'img/kartoza-logo-only.png' %}" height="20px"> BY <a href="http://kartoza.com/">KARTOZA</a></div>
                         </div>
                     </ul>
             </li>
@@ -70,7 +70,7 @@
                         <li><a class="nav-link js-scroll-trigger" href="/accounts/signup/">SIGN UP</a></li>
                      {% endif %}
                     <div class="bims-nav-footer row">
-                        <div class="col-lg-12">MADE WITH <img src="{% static 'img/kartoza-logo-only.png' %}" height="20px"> BY KARTOZA</div>
+                        <div class="col-lg-12">MADE WITH <img src="{% static 'img/kartoza-logo-only.png' %}" height="20px"> BY <a href="http://kartoza.com/">KARTOZA</a></div>
                     </div>
                     </ul>
             </li>

--- a/bims/templates/main_base.html
+++ b/bims/templates/main_base.html
@@ -79,7 +79,7 @@
       </div>
     </nav>
 
-
+    <script src="{% static "js/libs/jquery/jquery-3.3.1.min.js" %}"></script>
     <script>
 
         var burgerMenuButton = document.getElementById("menu-dropdown-burger");
@@ -111,6 +111,8 @@
         var biblioUrl = '{{ biblio_url }}';
         var profileUrl = '{{ profile_url }}';
         var contributionsUrl = '{{ contributions_url }}';
+        var titleAbbr = '{{ title_bims_abbr }}';
+        var titleLong = '{{ title_bims_long|safe }}';
 
         if(uploadUrl !== 'None'){
             var navbarUpload = document.getElementById("navbar-upload");
@@ -145,6 +147,14 @@
         if(contributionsUrl !== 'None'){
             var navbarContributions = document.getElementById("navbar-contributions");
             navbarContributions.href = contributionsUrl;
+        }
+
+        if(titleAbbr !== 'None'){
+            $(".bims-title-big").html(titleAbbr);
+        }
+
+        if(titleLong !== 'None'){
+            $('.bims-title-acc').html(titleLong);
         }
 
     </script>

--- a/bims/templates/map.html
+++ b/bims/templates/map.html
@@ -155,7 +155,7 @@
             <div class="row">
                 <div class="col-lg-12" style="padding-right: 0">
                     <span class="title">
-                        LAYERS SELECTOR
+                        LAYER SELECTOR
                     </span>
                     <div class="layers-selector-container-close close-button pull-right">
                         X


### PR DESCRIPTION
fix https://github.com/kartoza/LEDET_BIMS/issues/136

This PR:
- [x] if one selector is opened, others must closed. I opened the layer selector and then the base map selector and they overlapped.
- [x] I think the base map radios should be a separate section in the main layer selector rather than a separate selector with a different design
- [x] change 'layers selector' to 'layer selector'
- [x] html title across the site should be 'Limpopo BIMS'
- [x] add link to Kartoza home page

When one selector is opened, others are closed:
![peek 2018-07-05 18-02](https://user-images.githubusercontent.com/26101337/42319899-a257ac08-807d-11e8-8e92-73e57dbf0dc2.gif)

The html title can be changed through project.py settings:
- for changing the abbreviated title add: `TITLE_BIMS_ABBREVIATION`
e.g. `TITLE_BIMS_ABBREVIATION = LBIMS`
- for changing the long title add: `TITLE_BIMS_LONG`
e.g. `TITLE_BIMS_LONG` = `LIMPOPO BIODIVERSITY<br/>INFORMATION SYSTEM`

Link to Kartoza home page
![peek 2018-07-05 18-12](https://user-images.githubusercontent.com/26101337/42320405-70bd7df6-807f-11e8-9b9a-ae4bde4d6905.gif)