### PR TITLE
Add default layer OSM mapsurfer roads

### DIFF
--- a/bims/static/js/views/olmap_basemap.js
+++ b/bims/static/js/views/olmap_basemap.js
@@ -113,7 +113,7 @@ define(['backbone', 'underscore', 'jquery', 'ol', 'olMapboxStyle'], function (Ba
                 title: 'OSM Mapsurfer roads',
                 source: new ol.source.XYZ({
                     attributions: ['OpenStreetMap contributors, ODbL, Imagery GIScience Research Group @ Heidelberg University'],
-                    url: 'http://korona.geog.uni-heidelberg.de/tiles/roads/x={x}&y={y}&z={z}'
+                    url: 'https://korona.geog.uni-heidelberg.de/tiles/roads/x={x}&y={y}&z={z}'
                 })
             });
             baseSourceLayers.push(mapSurfer);

--- a/bims/static/js/views/olmap_basemap.js
+++ b/bims/static/js/views/olmap_basemap.js
@@ -52,6 +52,14 @@ define(['backbone', 'underscore', 'jquery', 'ol', 'olMapboxStyle'], function (Ba
                 layers: [openMapTiles, hillshading, contours]
             });
         },
+
+        getOSMMapsurferRoads: function () {
+            var layer = this.getOpenMapTilesTile(
+                staticURL + 'mapbox-style/positron-gl-style.json');
+            layer.set('title', 'Positron Map');
+            return layer
+        },
+
         getPositronBasemap: function () {
             var layer = this.getOpenMapTilesTile(
                 staticURL + 'mapbox-style/positron-gl-style.json');
@@ -100,11 +108,22 @@ define(['backbone', 'underscore', 'jquery', 'ol', 'olMapboxStyle'], function (Ba
                 baseSourceLayers.push(bingMap);
             }
 
+            // OSM MAPSURFER ROADS - Make default
+            var mapSurfer = new ol.layer.Tile({
+                title: 'OSM Mapsurfer roads',
+                source: new ol.source.XYZ({
+                    attributions: ['OpenStreetMap contributors, ODbL, Imagery GIScience Research Group @ Heidelberg University'],
+                    url: 'http://korona.geog.uni-heidelberg.de/tiles/roads/x={x}&y={y}&z={z}'
+                })
+            });
+            baseSourceLayers.push(mapSurfer);
+
             // OPENMAPTILES
             if (mapTilerKey) {
                 baseSourceLayers.push(this.getPositronBasemap());
                 baseSourceLayers.push(this.getDarkMatterBasemap());
                 baseSourceLayers.push(this.getKlokantechTerrainBasemap());
+                baseSourceLayers.push(this.getOSMMapsurferRoads());
             }
             $.each(baseSourceLayers, function (index, layer) {
                 layer.set('type', 'base');

--- a/bims/static/js/views/olmap_basemap.js
+++ b/bims/static/js/views/olmap_basemap.js
@@ -112,7 +112,7 @@ define(['backbone', 'underscore', 'jquery', 'ol', 'olMapboxStyle'], function (Ba
             var mapSurfer = new ol.layer.Tile({
                 title: 'OSM Mapsurfer roads',
                 source: new ol.source.XYZ({
-                    attributions: ['OpenStreetMap contributors, ODbL, Imagery GIScience Research Group @ Heidelberg University'],
+                    attributions: ['&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'],
                     url: 'https://korona.geog.uni-heidelberg.de/tiles/roads/x={x}&y={y}&z={z}'
                 })
             });


### PR DESCRIPTION
fix kartoza/LEDET_BIMS#65

The rest of the layers were added by @meomancer in https://github.com/kartoza/django-bims/pull/15
https://staging.limpopobims.kartoza.com/map
![layers](https://user-images.githubusercontent.com/10270148/43513359-d9a7df38-957d-11e8-903b-89d3b5022949.png)

I was adding the remaining layer 
- OSM mapsurfer roads

![ezgif com-optimize](https://user-images.githubusercontent.com/10270148/43513024-01c846ca-957d-11e8-86ec-a90757c95400.gif)
