### PR TITLE
Add admin action to update and delete location context.

### DIFF
--- a/bims/admin.py
+++ b/bims/admin.py
@@ -1,4 +1,9 @@
 # coding=utf-8
+import json
+from pygments import highlight
+from pygments.lexers.data import JsonLexer
+from pygments.formatters.html import HtmlFormatter
+
 from django import forms
 from django.utils.safestring import mark_safe
 from django.contrib.gis import admin
@@ -73,6 +78,8 @@ class LocationSiteAdmin(admin.GeoModelAdmin):
     default_lat = -30
     default_lon = 25
 
+    readonly_fields = ('location_context_prettified',)
+
     list_display = (
         'name', 'location_type', 'get_centroid', 'has_location_context')
     search_fields = ('name',)
@@ -126,6 +133,26 @@ class LocationSiteAdmin(admin.GeoModelAdmin):
 
     delete_location_context.short_description = (
         'Delete the selected location context documents.')
+
+    def location_context_prettified(self, instance):
+        """Function to display pretty format of location context."""
+        # Convert the data to sorted, indented JSON
+        data = json.loads(instance.location_context_document)
+        json_data_string = json.dumps(data, indent=2)
+
+        # Get the Pygments formatter
+        formatter = HtmlFormatter(style='colorful', noclasses=True)
+
+        # Highlight the data
+        response = highlight(json_data_string, JsonLexer(), formatter)
+
+        # Get the stylesheet
+        style = "<style>" + formatter.get_style_defs() + "</style><br>"
+
+        # Safe the output
+        return mark_safe(style + response)
+
+    location_context_prettified.short_description = 'Pretty Location Context'
 
 
 class IUCNStatusAdmin(admin.ModelAdmin):

--- a/bims/admin.py
+++ b/bims/admin.py
@@ -92,6 +92,10 @@ class LocationSiteAdmin(admin.GeoModelAdmin):
 
     def update_location_context(self, request, queryset):
         """Action method to update selected location contexts."""
+        if len(queryset) > 5:
+            message = 'You can not update for more than 5 location site.'
+            self.message_user(request, message)
+            return
         rows_updated = 0
         rows_failed = 0
         error_message = ''

--- a/deployment/ansible/development/site.yml
+++ b/deployment/ansible/development/site.yml
@@ -14,6 +14,7 @@
         2017.2
         2017.3
         2018.1
+        2018.2
         If not using Pycharm, just skip.
-      default: '2018.1'
+      default: '2018.2'
       private: no


### PR DESCRIPTION
Add two actions in the admin page for the location site:
- Update selected location site's context document
- Delete selected location site's context document
   ![delete_location_site](https://user-images.githubusercontent.com/1421861/44070402-d8ffbcec-9fad-11e8-9d18-c5f615e688da.gif)

- Show pretty format of the context document for easy to review and check
   <img width="974" alt="screen shot 2018-08-14 at 10 34 20" src="https://user-images.githubusercontent.com/1421861/44070383-c89ce7bc-9fad-11e8-8f09-11a25f89c6d2.png">


Purpose: 
- Faster testing (since I will need to update geocontext)
- Enable retrieve location site for a specific site (or do it gradually for all site)


Part of https://github.com/kartoza/LEDET_BIMS/issues/206