### PR TITLE
update cluster to show site instead records

### DIFF
--- a/bims/api_views/collection.py
+++ b/bims/api_views/collection.py
@@ -15,10 +15,11 @@ from bims.models.biological_collection_record import \
     BiologicalCollectionRecord
 from bims.models.taxon import Taxon
 from bims.serializers.bio_collection_serializer import (
-    BioCollectionSerializer,
     BioCollectionOneRowSerializer,
     BioCollectionGeojsonSerializer
 )
+from bims.serializers.location_site_serializer import \
+    LocationSiteClusterSerializer
 from bims.utils.cluster_point import (
     within_bbox,
     overlapping_area,
@@ -275,11 +276,16 @@ class ClusterCollection(GetCollectionAbstract):
         """
 
         cluster_points = []
+        sites = []
         for record in records:
             # get x,y of site
             record = record.object
             x = record.site.geometry_point.x
             y = record.site.geometry_point.y
+
+            if record.site_id in sites:
+                continue
+            sites.append(record.site_id)
 
             # check every point in cluster_points
             for pt in cluster_points:
@@ -301,8 +307,8 @@ class ClusterCollection(GetCollectionAbstract):
                     x - x_range * 1.5, y - y_range * 1.5,
                     x + x_range * 1.5, y + y_range * 1.5
                 )
-                serializer = BioCollectionSerializer(
-                    record)
+                serializer = LocationSiteClusterSerializer(
+                    record.site)
                 new_cluster = {
                     'count': 1,
                     'bbox': bbox,

--- a/bims/static/js/collections/cluster_biological.js
+++ b/bims/static/js/collections/cluster_biological.js
@@ -1,4 +1,4 @@
-define(['backbone', 'models/cluster_biological', 'views/cluster_biological', 'shared'], function (Backbone, ClusterModel, ClusterView, Shared) {
+define(['backbone', 'models/location_site', 'views/location_site', 'shared'], function (Backbone, ClusterModel, ClusterView, Shared) {
     return Backbone.Collection.extend({
         model: ClusterModel,
         apiParameters: _.template("?taxon=<%= taxon %>&search=<%= search %>" +


### PR DESCRIPTION
this fixes kartoza/healthyrivers/issues/166, fixes kartoza/healthyrivers/issues/167

This changes the cluster to use site instead records.
This issue : https://github.com/kartoza/healthyrivers/issues/167, occured because the cluster was based on record. So if there is cluster 6 (after zoomin to the max), it means 6 records is in one site.

Before:
Cluster shows 7 in total (total occurences)
![selection_065](https://user-images.githubusercontent.com/4530905/44504370-cfceba00-a6c5-11e8-8f21-ca0212127222.png)

After:
Cluster shows just 6 (total site)
![selection_063](https://user-images.githubusercontent.com/4530905/44504348-b2015500-a6c5-11e8-8c11-2f25ddf83eef.png)
![selection_064](https://user-images.githubusercontent.com/4530905/44504350-b75e9f80-a6c5-11e8-9bc2-e95e4d97a5df.png)
