### PR TITLE
Fix uploads shapefile not store to postgis

### DIFF
--- a/core/settings/contrib.py
+++ b/core/settings/contrib.py
@@ -275,3 +275,6 @@ ACCOUNT_APPROVAL_REQUIRED = False
 SOCIALACCOUNT_AUTO_SIGNUP = True
 ACCOUNT_ADAPTER = 'bims.adapters.account_adapter.AccountAdapter'
 ACCOUNT_EMAIL_VERIFICATION = 'mandatory'
+
+OGC_SERVER['default']['DATASTORE'] = os.environ.get(
+        'DEFAULT_BACKEND_DATASTORE', '')


### PR DESCRIPTION
For https://github.com/kartoza/LEDET_BIMS/issues/268

<img width="853" alt="image" src="https://user-images.githubusercontent.com/1979569/44845320-6d525c80-ac77-11e8-8f8c-64cdb2f4322b.png">

<img width="908" alt="image" src="https://user-images.githubusercontent.com/1979569/44845330-73483d80-ac77-11e8-87db-ca5622cea65d.png">

Geonode UI uploads now stored in the database 