### PR TITLE
change calculation of cluster

### DIFF
--- a/bims/static/js/views/layer_style.js
+++ b/bims/static/js/views/layer_style.js
@@ -100,7 +100,8 @@ define(['backbone', 'underscore', 'jquery', 'ol'], function (Backbone, _, $, ol)
                 scale: 1.3,
                 fill: new ol.style.Fill({
                     color: '#fff'
-                })
+                }),
+                'font': 'bold 11px "Roboto Condensed"'
             };
             if (count > this.maxCount) {
                 textStyle['text'] = '>' + this.maxCount;

--- a/bims/static/js/views/layer_style.js
+++ b/bims/static/js/views/layer_style.js
@@ -1,5 +1,7 @@
 define(['backbone', 'underscore', 'jquery', 'ol'], function (Backbone, _, $, ol) {
     return Backbone.View.extend({
+        maxCount: 500,
+        maxRadius: 30,
         styles: {
             'Point': new ol.style.Style({
                 image: new ol.style.Icon(/** @type {olx.style.IconOptions} */ ({
@@ -83,15 +85,10 @@ define(['backbone', 'underscore', 'jquery', 'ol'], function (Backbone, _, $, ol)
                 });
             } else {
                 var currentCount = count;
-                var radiusDivider = 10;
-                if (currentCount > 1000) {
-                    currentCount = 1000;
-                    radiusDivider = 30;
+                if (currentCount > this.maxCount) {
+                    currentCount = this.maxCount;
                 }
-                if (currentCount > 250 && currentCount < 1000) {
-                    radiusDivider = 20;
-                }
-                radius += (currentCount / radiusDivider);
+                radius += (currentCount / this.maxCount) * this.maxRadius;
                 image = new ol.style.Circle({
                     radius: radius,
                     fill: new ol.style.Fill({
@@ -105,10 +102,10 @@ define(['backbone', 'underscore', 'jquery', 'ol'], function (Backbone, _, $, ol)
                     color: '#fff'
                 })
             };
-            if (count > 500) {
-                textStyle['text'] = '> 500';
+            if (count > this.maxCount) {
+                textStyle['text'] = '>' + this.maxCount;
             } else if (count > 100) {
-                textStyle['text'] = '> 100' ;
+                textStyle['text'] = '>100';
             }
             return new ol.style.Style({
                 image: image,


### PR DESCRIPTION
Updating kartoza/django-bims/issues/155

Updating cluster style calculation

Calculation is:
```
radius = 7 + (currentCount / maxCount) * maxRadius;
```
minimum radius is 7 (lesser than this, making feature is too tiny)

maxCount = 500
maxRadius = 30

if currentCount > maxCount -> currentCount = maxCount

![selection_102](https://user-images.githubusercontent.com/4530905/45073907-83df3480-b10b-11e8-8104-16048c67fe07.png)
![selection_103](https://user-images.githubusercontent.com/4530905/45073910-85106180-b10b-11e8-8dc9-ac30e2e9e5d3.png)
