### PR TITLE
Hide uploads from geonode in admin page

### DIFF
--- a/bims/admin.py
+++ b/bims/admin.py
@@ -425,5 +425,10 @@ admin.site.register(SearchProcess, SearchProcessAdmin)
 
 admin.site.register(ReferenceLink, ReferenceLinkAdmin)
 
+# Hide upload files from geonode in admin
+from geonode.upload.models import Upload, UploadFile
+admin.site.unregister(Upload)
+admin.site.unregister(UploadFile)
+
 if TRACK_PAGEVIEWS:
     admin.site.register(Pageview, PageviewAdmin)


### PR DESCRIPTION
Fix https://github.com/kartoza/django-bims/issues/255