### PR TITLE
Fixed #514 - Removed species at the top and fixed spelling mistakes

### DIFF
--- a/bims/templates/map_page/dashboard-templates.html
+++ b/bims/templates/map_page/dashboard-templates.html
@@ -5,7 +5,6 @@
             Loading...
         </div>
     </div>
-    <div class="detailed-dashboard-title">&nbsp;</div>
     <button class="btn btn-primary btn-dashboard close-dashboard" style="float: right"><i class="fa fa-times pull-right"></i></button>
     <div class="container dashboard-wrapper">
         <div class="container row">
@@ -20,7 +19,7 @@
             <div class="col-lg-8 dashboard-graph-wrapper">
                 <div class="row">
                     <div class="col-lg-6">
-                        <h5 class="dd-title">Records overtime</h5>
+                        <h5 class="dd-title">Records over time</h5>
                         <div class="dashboard-table records-table"></div>
                     </div>
                     <div class="col-lg-6">


### PR DESCRIPTION
Fixed #514 - Removed species at the top and fixed spelling mistakes (Records overtime -> Records over time)

<img width="1369" alt="screenshot 2018-12-13 at 07 01 32" src="https://user-images.githubusercontent.com/34506346/49916844-5e4d8e00-fea5-11e8-993f-f90a3cf031ba.png">
