### PR TITLE
Fix river catchment filtering

### DIFF
--- a/bims/api_views/collection.py
+++ b/bims/api_views/collection.py
@@ -232,7 +232,7 @@ class GetCollectionAbstract(APIView):
             qs_river_catchment = SQ()
             qs = json.loads(river_catchments)
             for query in qs:
-                query = '_' + query + '_'
+                query = '_' + query.replace(' ', '_') + '_'
                 qs_river_catchment.add(SQ(river_catchments__contains=query),
                                        SQ.OR)
             results = results.filter(qs_river_catchment)

--- a/bims/indexes/biological_collection_record.py
+++ b/bims/indexes/biological_collection_record.py
@@ -210,9 +210,11 @@ class BiologicalCollectionIndex(indexes.SearchIndex, indexes.Indexable):
         if not obj.site.location_context_document:
             return ''
         river_catchment_array = get_river_catchment_site(obj.site)
-        if not river_catchment_array:
-            return ''
-        river_catchment_string = '_' + '_'.join(river_catchment_array) + '_'
+        river_catchment_string = ''
+        for river_catchment in river_catchment_array:
+            river_catchment_string += '_'
+            river_catchment_string += river_catchment.replace(' ', '_')
+            river_catchment_string += '_'
         return river_catchment_string
 
     class Meta:


### PR DESCRIPTION
This is because words are separated by space counts as two query, e.g : Region G -> [Region, G]. The solution is to replace the space with underscore.