### PR TITLE
Fixed styling on layer abstract layer so longer abstracts can be shown

### DIFF
--- a/bims/static/css/map.css
+++ b/bims/static/css/map.css
@@ -357,6 +357,7 @@ html, body, .map, .map-wrapper, #map-container {
     max-width: 100%;
     height: auto;
     padding: 0;
+    max-height: 200%;
 }
 
 #layers-selector li:hover .options {


### PR DESCRIPTION
This closes issue #717 

![newgif](https://user-images.githubusercontent.com/34506346/51627186-0ac16c00-1f4a-11e9-92be-8bcd7f925937.gif)
