### PR TITLE
SASS Form header no longer uses acronyms 

### DIFF
--- a/sass/templates/form_page.html
+++ b/sass/templates/form_page.html
@@ -180,10 +180,10 @@
             <thead>
             <tr>
                 <th scope="col">Taxon</th>
-                <th scope="col">S</th>
-                <th scope="col">Veg</th>
-                <th scope="col">GSM</th>
-                <th scope="col">TOT</th>
+                <th scope="col">Stones</th>
+                <th scope="col">Vegetation</th>
+                <th scope="col">Gravel, sand, mud</th>
+                <th scope="col">Total</th>
             </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
<img width="1117" alt="screenshot 2019-01-31 at 14 39 09" src="https://user-images.githubusercontent.com/34506346/52054701-09a1c780-2566-11e9-8868-4edd7f7d2e08.png">

This closes issue #740 
This closes issue #746 