### PR TITLE
Update add_location_context_group method

### DIFF
--- a/sass/views/sass_dashboard.py
+++ b/sass/views/sass_dashboard.py
@@ -163,7 +163,7 @@ class SassDashboardView(TemplateView):
             site_visit__sass_biotope_fraction__sass_biotope__biotope_form=1
         ).annotate(
             date=F('site_visit__site_visit_date'),
-            rate=F('site_visit__sass_biotope_fraction__rate'),
+            rate=F('site_visit__sass_biotope_fraction__rate__rate'),
             biotope=F('site_visit__sass_biotope_fraction__sass_biotope__name')
         ).values('date', 'rate', 'biotope').order_by(
             'site_visit__site_visit_date',


### PR DESCRIPTION
- Fix updating empty location_context_document data
- Will check existing location_context data, if found it will update the existing data
- Add group and site_id parameters to the management command, `python manage.py add_location_context_group -s {site_id} -g {group1,group2}`