### PR TITLE
remove flat function cause it causes error

### DIFF
--- a/bims/static/js/views/detail_dashboard/site_detail.js
+++ b/bims/static/js/views/detail_dashboard/site_detail.js
@@ -722,11 +722,11 @@ define([
             var choices = [];
             var index = 0;
             if (alias_type == 'cons_status') {
-                choices = data['iucn_name_list'].flat(1);
+                choices = data['iucn_name_list'];
             }
             if (alias_type == 'origin')
             {
-                choices = data['origin_name_list'].flat(1);}
+                choices = data['origin_name_list'];}
             if (choices.length > 0) {
                 index = choices.indexOf(alias) + 1;
                 name = choices[index];


### PR DESCRIPTION
Before fix:
I got this error when opening the site dashboard:
![Screenshot from 2019-03-14 14-07-01](https://user-images.githubusercontent.com/26101337/54338857-ac6d5b80-4665-11e9-9e96-d5484036b08f.png)

causing the dashboard to load indefinitely:
![Screenshot from 2019-03-14 14-07-23](https://user-images.githubusercontent.com/26101337/54338867-bb540e00-4665-11e9-9abd-81a9fddd319e.png)

After fix:
The culprit was the flat function, so I removed it.
here it is after fix:
![screencapture-0-0-0-0-63302-map-2019-03-14-14_17_28](https://user-images.githubusercontent.com/26101337/54338895-ce66de00-4665-11e9-9884-4795eef5b482.png)
