### PR TITLE
show commit id and branch name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,5 @@ deployment/ipt
 
 optimized.js
 deployment/geoserver_data
+.branch.txt
+.commit.txt

--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ optimized.js
 deployment/geoserver_data
 .branch.txt
 .commit.txt
+.tag.txt

--- a/Makefile
+++ b/Makefile
@@ -461,6 +461,7 @@ show-commit-and-branch:
 	@echo "--------------------------"
 	@git rev-parse HEAD > .commit.txt
 	@git rev-parse --abbrev-ref HEAD > .branch.txt
+	@git describe --tags > .tag.txt
 
 # --------------- help --------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -455,6 +455,12 @@ update-ecological-data:
 	@echo "--------------------------"
 	@docker-compose exec uwsgi python manage.py update_ecological_data
 
+show-commit-and-branch:
+	@echo "--------------------------"
+	@echo "Update and show commit ID and branch name of this deployment on display"
+	@echo "--------------------------"
+	@git rev-parse HEAD > .commit.txt
+	@git rev-parse --abbrev-ref HEAD > .branch.txt
 
 # --------------- help --------------------------------
 

--- a/bims/context_processor.py
+++ b/bims/context_processor.py
@@ -3,7 +3,7 @@
 Our custom context processors
 """
 import ast
-
+import os
 from django.conf import settings
 from bims.utils.get_key import get_key
 
@@ -120,5 +120,17 @@ def custom_navbar_url(request):
         context['title_bims_long'] = settings.TITLE_BIMS_LONG
     except AttributeError:
         context['title_bims_long'] = None
+
+    path_commit_file = '.commit.txt'
+    commit_file = os.path.isfile(path_commit_file)
+    if commit_file:
+        with open(path_commit_file) as file:
+            context['commit_id'] = file.readline()
+
+    path_branch_file = '.branch.txt'
+    branch_file = os.path.isfile(path_branch_file)
+    if branch_file:
+        with open(path_branch_file) as file:
+            context['branch_name'] = file.readline()
 
     return context

--- a/bims/context_processor.py
+++ b/bims/context_processor.py
@@ -132,5 +132,11 @@ def custom_navbar_url(request):
     if branch_file:
         with open(path_branch_file) as file:
             context['branch_name'] = file.readline()
+        if context['branch_name'] != 'develop':
+            path_tag_file = '.tag.txt'
+            tag_file = os.path.isfile(path_tag_file)
+            if tag_file:
+                with open(path_tag_file) as tag:
+                    context['tag_version'] = tag.readline()
 
     return context

--- a/bims/static/css/base.css
+++ b/bims/static/css/base.css
@@ -284,3 +284,14 @@ h6 {
         max-width: 550px;
     }
 }
+
+.git-info {
+    font-size: 10pt;
+    margin-top: 10px;
+    color: darkgrey;
+}
+
+.git-item {
+    color: whitesmoke;
+    margin-left: 5px;
+}

--- a/bims/templates/landing_page.html
+++ b/bims/templates/landing_page.html
@@ -50,8 +50,10 @@
             </div>
             {% endif %}
         </div>
-    {% if commit_id and branch_name %}
+    {% if commit_id and branch_name and not tag_version%}
         <div class="row git-info">Checked out from commit: <span class="git-item">{{ commit_id }}</span>, branch: <span class="git-item">{{ branch_name }}</span></div>
+    {% elif tag_version %}
+        <div class="row git-info">Version: <span class="git-item"> {{ tag_version }}</span></div>
     {% endif %}
     </div>
     </section>

--- a/bims/templates/landing_page.html
+++ b/bims/templates/landing_page.html
@@ -50,6 +50,9 @@
             </div>
             {% endif %}
         </div>
+    {% if commit_id and branch_name %}
+        <div class="row git-info">Checked out from commit: <span class="git-item">{{ commit_id }}</span>, branch: <span class="git-item">{{ branch_name }}</span></div>
+    {% endif %}
     </div>
     </section>
     </div>


### PR DESCRIPTION
fix #213 

This PR add command on makefile to write the commit id to `.commit.txt` and branch name to `.branch.txt`
just do `make show-commit-and-branch`
It will add both files and will be read as context: `commit_id` and `branch_name` and they can be used on templates.

e.g.
![Screenshot from 2019-10-18 12-54-16](https://user-images.githubusercontent.com/26101337/67069199-892fff00-f1a6-11e9-885d-9a13751573a2.png)


When branch is not develop it will display version from .tag.txt
![Screenshot from 2019-10-25 09-33-08](https://user-images.githubusercontent.com/26101337/67538962-eda11000-f70a-11e9-95fc-23c7cd293805.png)
