### PR TITLE
Return taxonomy name instead of original species name in csv

### DIFF
--- a/bims/serializers/bio_collection_serializer.py
+++ b/bims/serializers/bio_collection_serializer.py
@@ -234,6 +234,9 @@ class BioCollectionOneRowSerializer(serializers.ModelSerializer):
             return '-'
 
     def get_taxon(self, obj):
+        if obj.taxonomy:
+            if obj.taxonomy.canonical_name:
+                return obj.taxonomy.canonical_name
         if obj.original_species_name:
             return obj.original_species_name
         return '-'


### PR DESCRIPTION
Fixes https://github.com/kartoza/django-bims/issues/2777