### PR TITLE
Turn FBIS data on and off

### DIFF
--- a/bims/static/js/views/filter_panel/source_collection.js
+++ b/bims/static/js/views/filter_panel/source_collection.js
@@ -58,7 +58,6 @@ define([
                 // If source_collection named fbis is first => set the checkbox disabled
                 if (data[i].get('source_collection') === 'fbis' && i === 0) {
                     isFBIS = true;
-                    checked += ' disabled';
                 }
 
                 let dataSourceCaption = '';


### PR DESCRIPTION
fix #2853

![image](https://user-images.githubusercontent.com/12623986/144080256-dd07043e-5727-4e60-96ad-6ccf67f9553d.png)

To change the Data Sources default to GBIF data, you can change the value of _Map default filters_ in  Site Sittings from admin page