### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -12,7 +12,7 @@ jobs:
     steps:	
     - uses: actions/checkout@master	
     - name: Build and Publish the Docker Django Bims Image	
-      uses: elgohr/Publish-Docker-Github-Action@master	
+      uses: elgohr/Publish-Docker-Github-Action@v5	
       with:	
         name: kartoza/kbims_uwsgi:latest
         context: .


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore