### PR TITLE
Parse and handle language codes in common names

### DIFF
--- a/bims/scripts/taxa_upload.py
+++ b/bims/scripts/taxa_upload.py
@@ -82,19 +82,23 @@ class TaxaProcessor(object):
         common_names = common_name_value.split(',')
         for common_name in common_names:
             common_name = common_name.strip()
-            try:
-                vernacular_name, _ = VernacularName.objects.get_or_create(
-                    name=common_name,
-                    language='en',
-                    is_upload=True
-                )
-            except VernacularName.MultipleObjectsReturned:
-                vernacular_name = VernacularName.objects.filter(
-                    name=common_name,
-                    language='en',
-                    is_upload=True
-                )[0]
-            vernacular_names.append(vernacular_name)
+            match = re.match(r'^(.*?)(?: \((\w+)\))?$', common_name)
+            if match:
+                name = match.group(1)
+                language = match.group(2) if match.group(2) else 'eng'
+                try:
+                    vernacular_name, _ = VernacularName.objects.get_or_create(
+                        name=name,
+                        language=language,
+                        is_upload=True
+                    )
+                except VernacularName.MultipleObjectsReturned:
+                    vernacular_name = VernacularName.objects.filter(
+                        name=name,
+                        language=language,
+                        is_upload=True
+                    )[0]
+                vernacular_names.append(vernacular_name)
         return vernacular_names
 
     def origin(self, row):

--- a/bims/tests/data/taxa_upload_family.csv
+++ b/bims/tests/data/taxa_upload_family.csv
@@ -1,6 +1,6 @@
 ﻿Taxon Rank,Kingdom,Phylum,Class,Order,Family,Genus,Species,SubSpecies,Taxon,Accepted Taxon,Taxonomic status,Scientific name and authority,Common Name,Origin,Endemism,Conservation status global,Conservation status national,lentic,On GBIF,Lakes (Y/N),Author(s)
 Kingdom,Animalia,,,,,,,,Animalia,,accepted,Animalia,,,,,,,No,,
 Phylum,Animalia,Annelida,,,,,,,Annelida,,accepted,Annelida,,,,,,,No,,
-Class,Animalia,Annelida,Oligochaeta,,,,,,Oligochaeta,,accepted,Oligochaeta,Earthworm,Native,Unknown,Not evaluated,,,No,,
+Class,Animalia,Annelida,Oligochaeta,,,,,,Oligochaeta,,accepted,Oligochaeta,"Earthworm (eng), Earthworm2, ミミズ (jpn)",Native,Unknown,Not evaluated,,,No,,
 Family,Animalia,Arthropoda,Insecta,Trichoptera,Ecnomidae,,,,Ecnomidae,,accepted,Ecnomidae,trattnattsländor,Unknown,Unknown,Not evaluated,,Y,No,Y,Dimas 1789
 Family,Animalia,Arthropoda,Insecta,Trichoptera,Ecnomidae2,,,,Ecnomidae2,Ecnomidae,synonym,Ecnomidae2,"test1,test2,test3",Unknown,Unknown,Not evaluated,,,No,,

--- a/bims/tests/test_taxa_upload.py
+++ b/bims/tests/test_taxa_upload.py
@@ -58,8 +58,25 @@ class TestTaxaUpload(FastTenantTestCase):
 
         self.assertTrue(
             VernacularName.objects.filter(
-                name='test1',
-                taxonomy__canonical_name__icontains='Ecnomidae2'
+                name='Earthworm',
+                language='eng',
+                taxonomy__canonical_name__icontains='Oligochaeta'
+            )
+        )
+
+        self.assertTrue(
+            VernacularName.objects.filter(
+                name='Earthworm2',
+                language='eng',
+                taxonomy__canonical_name__icontains='Oligochaeta'
+            )
+        )
+
+        self.assertTrue(
+            VernacularName.objects.filter(
+                name='ミミズ',
+                language='jpn',
+                taxonomy__canonical_name__icontains='Oligochaeta'
             )
         )
 


### PR DESCRIPTION
- Updated `common_name` method to check for language codes within brackets in the common name string.
- Defaulted to 'eng' language code if no language is specified.

Example handled: "Earthworm (eng), Earthworm2, ミミズ (jpn)"

https://github.com/kartoza/django-bims/issues/3950