### PR TITLE
Fix unclosed file handles

### DIFF
--- a/bims/api_views/get_biorecord.py
+++ b/bims/api_views/get_biorecord.py
@@ -73,8 +73,8 @@ class BioCollectionSummary(APIView):
         if search_process.file_path:
             if os.path.exists(search_process.file_path):
                 try:
-                    raw_data = open(search_process.file_path)
-                    return Response(json.load(raw_data))
+                    with open(search_process.file_path) as raw_data:
+                        return Response(json.load(raw_data))
                 except ValueError:
                     pass
 
@@ -178,9 +178,8 @@ class BioCollectionSummary(APIView):
             search_process=search_process,
             finished=True
         )
-        file_data = open(file_path)
-
-        try:
-            return Response(json.load(file_data))
-        except ValueError:
-            return Response(response_data)
+        with open(file_path) as file_data:
+            try:
+                return Response(json.load(file_data))
+            except ValueError:
+                return Response(response_data)


### PR DESCRIPTION
## Summary
- handle cached summary files with context managers

## Testing
- `python -m py_compile bims/api_views/get_biorecord.py`
- `pytest -k "" -q` *(fails: ModuleNotFoundError: No module named 'tenant_schemas_celery')*

------
https://chatgpt.com/codex/tasks/task_e_6840095e75508333a5243ad4df2788e3