### PR TITLE
Add iucn util to harvest data

### DIFF
--- a/bims/management/commands/test_iucn_api.py
+++ b/bims/management/commands/test_iucn_api.py
@@ -1,0 +1,65 @@
+import json
+
+from django.core.management.base import BaseCommand
+from django_tenants.utils import get_tenant_model, schema_context
+
+from bims.utils import iucn
+from bims.models.taxonomy import Taxonomy
+
+
+class Command(BaseCommand):
+    help = "Test IUCN API functions within a specific tenant."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--schema', required=True,
+            help='Tenant schema name (e.g. sa_namibia)'
+        )
+        parser.add_argument(
+            '--assessment-id', type=int,
+            help='IUCN Assessment ID to test get_assessment_detail'
+        )
+        parser.add_argument(
+            '--habitat-code', type=str,
+            help='Habitat code to test fetch_taxa'
+        )
+        parser.add_argument(
+            '--taxon-id', type=int,
+            help='Taxonomy model ID to test get_iucn_status'
+        )
+
+    def handle(self, *args, **options):
+        schema_name = options['schema']
+        TenantModel = get_tenant_model()
+
+        try:
+            tenant = TenantModel.objects.get(schema_name=schema_name)
+        except TenantModel.DoesNotExist:
+            self.stderr.write(self.style.ERROR(f"Tenant with schema '{schema_name}' not found."))
+            return
+
+        with schema_context(schema_name):
+            self.stdout.write(self.style.SUCCESS(f"Using tenant schema: {schema_name}"))
+
+            assessment_id = options.get('assessment_id')
+            habitat_code = options.get('habitat_code')
+            taxon_id = options.get('taxon_id')
+
+            if assessment_id:
+                self.stdout.write(self.style.NOTICE(f'Testing get_assessment_detail({assessment_id})...'))
+                data = iucn.get_assessment_detail(assessment_id)
+                self.stdout.write(self.style.SUCCESS(str(json.dumps(data, indent=4))))
+
+            if habitat_code:
+                self.stdout.write(self.style.NOTICE(f'Testing fetch_taxa("{habitat_code}")...'))
+                data = iucn.fetch_taxa(habitat_code)
+                self.stdout.write(self.style.SUCCESS(str(json.dumps(data, indent=4))))
+
+            if taxon_id:
+                try:
+                    taxon = Taxonomy.objects.get(id=taxon_id)
+                    self.stdout.write(self.style.NOTICE(f'Testing get_iucn_status(taxon={taxon})...'))
+                    status, sis_id, url = iucn.get_iucn_status(taxon)
+                    self.stdout.write(self.style.SUCCESS(f"IUCN Status: {status}, SIS ID: {sis_id}, URL: {url}"))
+                except Taxonomy.DoesNotExist:
+                    self.stdout.write(self.style.ERROR(f"Taxonomy with ID {taxon_id} not found."))

--- a/bims/utils/iucn.py
+++ b/bims/utils/iucn.py
@@ -1,13 +1,106 @@
 import logging
-
 import requests
 from requests.exceptions import HTTPError, SSLError
 
 from bims.models.iucn_status import IUCNStatus
 from preferences import preferences
 
-
 logger = logging.getLogger(__name__)
+
+
+def _make_iucn_request(endpoint: str, params: dict = None) -> dict | None:
+    """
+    Makes a GET request to the IUCN API.
+    """
+    api_key = preferences.SiteSetting.iucn_api_key
+    if not api_key:
+        return None
+
+    url = f'https://api.iucnredlist.org/api/v4/{endpoint}'
+    headers = {
+        'accept': 'application/json',
+        'Authorization': api_key
+    }
+
+    try:
+        response = requests.get(url, headers=headers, params=params)
+        response.raise_for_status()
+        result = response.json()
+        if isinstance(result, dict):
+            if 'total-count' in response.headers:
+                result['total_count'] = response.headers.get('total-count', 0)
+            if 'total-pages' in response.headers:
+                result['total_pages'] = response.headers.get('total-pages', 0)
+            if 'current-page' in response.headers:
+                result['current_page'] = response.headers.get('current-page', 0)
+        return result
+    except (HTTPError, SSLError,
+            requests.exceptions.JSONDecodeError,
+            requests.exceptions.RequestException) as e:
+        logger.error(f"IUCN API error: {e}")
+        return None
+
+
+def get_assessment_detail(assessment_id: int) -> dict | None:
+    """
+    Retrieve IUCN assessment details for a given assessment ID.
+
+    Args:
+        assessment_id (int): The unique ID of the assessment.
+
+    Returns:
+        dict | None: A dictionary containing assessment details if successful,
+        otherwise None if the request fails or the ID is invalid.
+    """
+    if not assessment_id:
+        return None
+    return _make_iucn_request(f'assessment/{assessment_id}')
+
+
+def fetch_taxa(habitat_code: str, page: int = 1, per_page: int = 100) -> dict:
+    """
+    Retrieve a list of taxa associated with a specific habitat code.
+
+    Also returns pagination metadata from response headers if present.
+
+    Args:
+        habitat_code (str): The IUCN habitat classification code.
+        page (int): Page number to fetch.
+        per_page (int): Number of items per page.
+
+    Returns:
+        dict: {
+            "results": list of taxa records,
+            "total_count": int,
+            "total_pages": int,
+            "current_page": int,
+        }
+    """
+    if not habitat_code:
+        return {
+            "results": [],
+            "total_count": 0,
+            "total_pages": 0,
+            "current_page": 0,
+        }
+
+    params = {"page": page, "per_page": per_page}
+    result = _make_iucn_request(f'habitats/{habitat_code}', params=params)
+
+    if result is None:
+        return {
+            "results": [],
+            "total_count": 0,
+            "total_pages": 0,
+            "current_page": page,
+        }
+
+    return {
+        "results": result.get('assessments', []),
+        "total_count": int(result.get("total_count", 0)),
+        "total_pages": int(result.get("total_pages", 0)),
+        "current_page": int(result.get("current_page", page)),
+    }
 
 
 def get_iucn_status(taxon):
@@ -18,60 +111,44 @@ def get_iucn_status(taxon):
     :param taxon: Taxonomy instance (must have genus_name and species_name)
     :return: tuple (IUCNStatus or None, sis_id or None, iucn_url or None)
     """
-    api_iucn_key = preferences.SiteSetting.iucn_api_key
-
-    if not api_iucn_key or not taxon.genus_name or not taxon.species_name:
+    if not taxon.genus_name or not taxon.species_name:
         return None, None, None
-
-    url = "https://api.iucnredlist.org/api/v4/taxa/scientific_name"
-    headers = {
-        'accept': 'application/json',
-        'Authorization': api_iucn_key
-    }
 
     species_name = taxon.species_name
     genus_name = taxon.genus_name
-
-    if genus_name in species_name:
-        species_name = species_name.replace(genus_name, '', 1).strip()
+    species_name = (
+        taxon.species_name.replace(genus_name, '', 1).strip() if genus_name in species_name else species_name
+    )
 
     params = {
         'genus_name': genus_name,
         'species_name': species_name
     }
 
+    json_result = _make_iucn_request('taxa/scientific_name', params)
+    if not json_result:
+        return None, None, None
+
+    sis_id = json_result.get("taxon", {}).get("sis_id")
     iucn_url = None
 
-    try:
-        response = requests.get(url, headers=headers, params=params)
-        response.raise_for_status()
-        json_result = response.json()
+    assessments = json_result.get("assessments", [])
+    latest = next((a for a in assessments if a.get("latest")), None)
 
-        sis_id = json_result.get("taxon", {}).get("sis_id")
+    if latest:
+        category = latest.get("red_list_category_code")
+        iucn_url = latest.get("url")
+        if category:
+            try:
+                iucn_status, _ = IUCNStatus.objects.get_or_create(
+                    category=category,
+                    national=False
+                )
+            except IUCNStatus.MultipleObjectsReturned:
+                iucn_status = IUCNStatus.objects.filter(
+                    category=category,
+                    national=False
+                ).first()
+            return iucn_status, sis_id, iucn_url
 
-        assessments = json_result.get("assessments", [])
-        latest = next((a for a in assessments if a.get("latest")), None)
-
-        if latest:
-            category = latest.get("red_list_category_code")
-            iucn_url = latest.get("url")
-            if category:
-                try:
-                    iucn_status, _ = IUCNStatus.objects.get_or_create(
-                        category=category,
-                        national=False
-                    )
-                except IUCNStatus.MultipleObjectsReturned:
-                    iucn_status = IUCNStatus.objects.filter(
-                        category=category,
-                        national=False
-                    ).first()
-                return iucn_status, sis_id, iucn_url
-
-        return None, sis_id, iucn_url
-
-    except (HTTPError, SSLError,
-            requests.exceptions.JSONDecodeError,
-            requests.exceptions.RequestException) as e:
-        logger.error(f"IUCN API error: {e}")
-        return None, None, iucn_url
+    return None, sis_id, iucn_url


### PR DESCRIPTION
This pull request introduces enhancements to the IUCN API integration, including the addition of a new management command for testing API functions and significant refactoring of the API utility methods. These changes improve code modularity, error handling, and functionality.

### New functionality:
* [`bims/management/commands/test_iucn_api.py`](diffhunk://#diff-557dd3d92a4033c43af5a7b9784b164b644c6b4c7bd7e25c95b93b6019ba7e7dR1-R65): Added a new Django management command `test_iucn_api` to test IUCN API functions (`get_assessment_detail`, `fetch_taxa`, and `get_iucn_status`) within a specific tenant schema. This includes argument parsing for tenant schema, assessment ID, habitat code, and taxonomy ID.

### Refactoring and improvements to API utilities:
* [`bims/utils/iucn.py`](diffhunk://#diff-fb8bf8a79b229930db5c4bf113a34ca12c2778dd1e758fd6ea6f26f3e9e0c010L2-R105): Introduced `_make_iucn_request`, a helper function to centralize IUCN API requests, handle headers, and parse response metadata for pagination. This improves code reuse and error handling.
* [`bims/utils/iucn.py`](diffhunk://#diff-fb8bf8a79b229930db5c4bf113a34ca12c2778dd1e758fd6ea6f26f3e9e0c010L2-R105): Refactored `get_assessment_detail` and `fetch_taxa` to use `_make_iucn_request`, adding support for structured response data and pagination metadata.
* [`bims/utils/iucn.py`](diffhunk://#diff-fb8bf8a79b229930db5c4bf113a34ca12c2778dd1e758fd6ea6f26f3e9e0c010L21-R133): Updated `get_iucn_status` to use `_make_iucn_request`, simplifying the code and removing redundant error handling logic. [[1]](diffhunk://#diff-fb8bf8a79b229930db5c4bf113a34ca12c2778dd1e758fd6ea6f26f3e9e0c010L21-R133) [[2]](diffhunk://#diff-fb8bf8a79b229930db5c4bf113a34ca12c2778dd1e758fd6ea6f26f3e9e0c010L72-L77)