### PR TITLE
Fix get_iucn_status for new taxon

### DIFF
--- a/bims/api_views/taxon.py
+++ b/bims/api_views/taxon.py
@@ -30,7 +30,6 @@ from bims.utils.gbif import suggest_search, update_taxonomy_from_gbif, get_verna
 from bims.serializers.tag_serializer import TagSerializer, TaxonomyTagUpdateSerializer
 from bims.models.taxonomy_update_proposal import TaxonomyUpdateProposal
 from bims.utils.iucn import get_iucn_status
-from bims.utils.user import get_user
 
 logger = logging.getLogger('bims')
 

--- a/bims/management/commands/update_iucn_taxa.py
+++ b/bims/management/commands/update_iucn_taxa.py
@@ -1,7 +1,7 @@
 import json
 from django.core.management.base import BaseCommand
 from django.contrib.gis.db import models
-from bims.utils.iucn import get_iucn_status
+from bims.utils.iucn import get_iucn_statusget_iucn_status, get_iucn_status
 from bims.models.taxonomy import Taxonomy
 from bims.models.biological_collection_record import (
     collection_post_save_update_cluster,

--- a/bims/utils/iucn.py
+++ b/bims/utils/iucn.py
@@ -20,7 +20,17 @@ def get_iucn_status(taxon):
     """
     api_iucn_key = preferences.SiteSetting.iucn_api_key
 
-    if not api_iucn_key or not taxon.genus_name or not taxon.species_name:
+    species_name = taxon.species_name
+    taxon_name_list = species_name.split(' ')
+    if not taxon.parent and species_name and len(taxon_name_list) > 1:
+        genus_name = taxon_name_list[0].strip()
+    else:
+        genus_name = taxon.genus_name
+
+    if genus_name and genus_name in species_name:
+        species_name = species_name.replace(genus_name, '', 1).strip()
+
+    if not api_iucn_key or not genus_name or not species_name:
         return None, None, None
 
     url = "https://api.iucnredlist.org/api/v4/taxa/scientific_name"
@@ -28,12 +38,6 @@ def get_iucn_status(taxon):
         'accept': 'application/json',
         'Authorization': api_iucn_key
     }
-
-    species_name = taxon.species_name
-    genus_name = taxon.genus_name
-
-    if genus_name in species_name:
-        species_name = species_name.replace(genus_name, '', 1).strip()
 
     params = {
         'genus_name': genus_name,


### PR DESCRIPTION
This pull request introduces changes to improve the handling of taxon data and refactor code related to IUCN status retrieval.

### Improvements to IUCN status retrieval:

* [`bims/utils/iucn.py`](diffhunk://#diff-fb8bf8a79b229930db5c4bf113a34ca12c2778dd1e758fd6ea6f26f3e9e0c010L23-R33): Refined the logic in the `get_iucn_status` function to handle cases where the `genus_name` is not explicitly provided but can be inferred from the `species_name`. This ensures more accurate API requests for taxa without a parent genus. [[1]](diffhunk://#diff-fb8bf8a79b229930db5c4bf113a34ca12c2778dd1e758fd6ea6f26f3e9e0c010L23-R33) [[2]](diffhunk://#diff-fb8bf8a79b229930db5c4bf113a34ca12c2778dd1e758fd6ea6f26f3e9e0c010L32-L37)

### Code cleanup:

* [`bims/api_views/taxon.py`](diffhunk://#diff-01c08d1d41f87d718135f196d9275c2b0eacd39c4e44868c62827b3cb8427e32L33): Removed an unused import for `get_user`, improving code readability.
* [`bims/management/commands/update_iucn_taxa.py`](diffhunk://#diff-e65690b295938837cae1194d938d243c79d232b7917ac59d34cdda992d92d2deL4-R4): Fixed a redundant import of `get_iucn_status` by consolidating it into a single line.