### PR TITLE
Add menu to taxon management page for authenticated non staff user

### DIFF
--- a/bims/templates/fbis/navigation_bar.html
+++ b/bims/templates/fbis/navigation_bar.html
@@ -104,6 +104,10 @@
                         <li class="dropdown-menu-item"><a href="/profile/">Profile</a></li>
                         <li class="dropdown-menu-item"><a href="/site-visit/list/?&collectors=%5B{{ user.id }}%5D">Site Visits</a></li>
                         <li class="dropdown-menu-item"><a href="/download-request/">Download Requests</a></li>
+                        {% if not user.is_superuser %}
+                        <li class="dropdown-divider"></li>
+                        <li class="dropdown-menu-item"><a href="/taxa-management/">Taxon Management</a></li>
+                        {% endif %}
                     </ul>
                 </li>
                 {% if user.is_superuser %}


### PR DESCRIPTION
[Update FBIS so that Taxon Management is available for ordinary users as per other BIMS](https://github.com/kartoza/django-bims/issues/4924)