### PR TITLE
Add species checklist upload type option

### DIFF
--- a/bims/admin.py
+++ b/bims/admin.py
@@ -139,7 +139,7 @@ from bims.models import (
     TaxonGroupCitation,
     HarvestSchedule,
     OccurrenceUploadTemplate,
-    UploadRequest, CertaintyHierarchy,
+    UploadRequest, UploadType, CertaintyHierarchy,
     FilterPanelInfo
 )
 from bims.utils.fetch_gbif import merge_taxa_data
@@ -2886,6 +2886,13 @@ class HarvestScheduleAdmin(admin.ModelAdmin):
         updated = queryset.update(enabled=False)
         self.message_user(
             request, f"Disabled {updated} schedule(s).", messages.SUCCESS)
+
+
+@admin.register(UploadType)
+class UploadTypeAdmin(admin.ModelAdmin):
+    list_display = ('order', 'name', 'code')
+    search_fields = ('name', 'code', 'description')
+    ordering = ('order',)
 
 
 @admin.register(UploadRequest)

--- a/bims/forms/upload.py
+++ b/bims/forms/upload.py
@@ -2,7 +2,7 @@
 from django import forms
 from django.core.exceptions import ValidationError
 from django.core.validators import FileExtensionValidator
-from bims.models.upload_request import UploadRequest
+from bims.models.upload_request import UploadRequest, UploadType
 
 ALLOWED_EXTENSIONS = [
     'csv', 'xlsx', 'xls', 'zip',
@@ -16,8 +16,11 @@ class UploadForm(forms.Form):
     title = forms.CharField(max_length=255)
     name = forms.CharField(max_length=200)
     email = forms.EmailField()
-    upload_type = forms.ChoiceField(
-        choices=UploadRequest.TYPE_CHOICES)
+    upload_type = forms.ModelChoiceField(
+        queryset=UploadType.objects.all().order_by('order'),
+        empty_label=None,
+        to_field_name='code'
+    )
     upload_file = forms.FileField(
         validators=[FileExtensionValidator(
             allowed_extensions=ALLOWED_EXTENSIONS)

--- a/bims/migrations/0491_uploadtype_model.py
+++ b/bims/migrations/0491_uploadtype_model.py
@@ -1,0 +1,119 @@
+# Generated manually for UploadType refactoring
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+def populate_upload_types(apps, schema_editor):
+    """Create initial UploadType records"""
+    UploadType = apps.get_model('bims', 'UploadType')
+
+    types = [
+        {'name': 'Occurrence Data', 'code': 'occurrence', 'order': 1},
+        {'name': 'Spatial Layer', 'code': 'spatial', 'order': 2},
+        {'name': 'Species Checklist or Taxonomic Resource', 'code': 'species-checklist', 'order': 3},
+    ]
+
+    for type_data in types:
+        UploadType.objects.get_or_create(
+            code=type_data['code'],
+            defaults={'name': type_data['name'], 'order': type_data['order']}
+        )
+
+
+def migrate_upload_type_data(apps, schema_editor):
+    """Migrate existing upload_type string values to ForeignKey"""
+    UploadRequest = apps.get_model('bims', 'UploadRequest')
+    UploadType = apps.get_model('bims', 'UploadType')
+
+    # Create a mapping of code to UploadType instance
+    type_map = {ut.code: ut for ut in UploadType.objects.all()}
+
+    # Update all UploadRequest records
+    for request in UploadRequest.objects.all():
+        if request.upload_type_old and request.upload_type_old in type_map:
+            request.upload_type = type_map[request.upload_type_old]
+            request.save(update_fields=['upload_type'])
+
+
+def reverse_migrate_data(apps, schema_editor):
+    """Reverse migration: copy FK back to string field"""
+    UploadRequest = apps.get_model('bims', 'UploadRequest')
+
+    for request in UploadRequest.objects.all():
+        if request.upload_type:
+            request.upload_type_old = request.upload_type.code
+            request.save(update_fields=['upload_type_old'])
+
+
+class Migration(migrations.Migration):
+
+    atomic = False  # Disable atomic transactions to avoid pending trigger events
+
+    dependencies = [
+        ('bims', '0490_iucnassessment'),
+    ]
+
+    operations = [
+        # Step 1: Create UploadType model
+        migrations.CreateModel(
+            name='UploadType',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(help_text='Display name for the upload type', max_length=255)),
+                ('code', models.CharField(help_text='Unique identifier code (e.g., occurrence, spatial, species-checklist)', max_length=50, unique=True)),
+                ('description', models.TextField(blank=True, help_text='Optional description', null=True)),
+                ('order', models.IntegerField(default=0, help_text='Display order in forms')),
+            ],
+            options={
+                'verbose_name': 'Upload Type',
+                'verbose_name_plural': 'Upload Types',
+                'ordering': ('order',),
+            },
+        ),
+
+        # Step 2: Populate UploadType with initial data
+        migrations.RunPython(populate_upload_types, migrations.RunPython.noop),
+
+        # Step 3: Rename existing upload_type field to upload_type_old
+        migrations.RenameField(
+            model_name='uploadrequest',
+            old_name='upload_type',
+            new_name='upload_type_old',
+        ),
+
+        # Step 4: Add new upload_type ForeignKey field (nullable for now)
+        migrations.AddField(
+            model_name='uploadrequest',
+            name='upload_type',
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                help_text='Type of upload request',
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name='upload_requests',
+                to='bims.uploadtype'
+            ),
+        ),
+
+        # Step 5: Migrate data from old field to new field
+        migrations.RunPython(migrate_upload_type_data, reverse_migrate_data),
+
+        # Step 6: Make upload_type non-nullable
+        migrations.AlterField(
+            model_name='uploadrequest',
+            name='upload_type',
+            field=models.ForeignKey(
+                help_text='Type of upload request',
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name='upload_requests',
+                to='bims.uploadtype'
+            ),
+        ),
+
+        # Step 7: Remove the old upload_type_old field
+        migrations.RemoveField(
+            model_name='uploadrequest',
+            name='upload_type_old',
+        ),
+    ]

--- a/bims/models/__init__.py
+++ b/bims/models/__init__.py
@@ -74,6 +74,6 @@ from bims.models.tag_group import TagGroup
 from bims.models.dataset import Dataset
 from bims.models.taxon_group_citation import TaxonGroupCitation
 from bims.models.harvest_schedule import HarvestSchedule
-from bims.models.upload_request import UploadRequest
+from bims.models.upload_request import UploadRequest, UploadType
 from bims.models.certainty_hierarchy import CertaintyHierarchy
 from bims.models.filter_panel_info import FilterPanelInfo

--- a/bims/models/upload_request.py
+++ b/bims/models/upload_request.py
@@ -8,17 +8,44 @@ def upload_path(instance, filename):
     base, ext = os.path.splitext(filename)
     return f"uploads/{instance.created_at:%Y/%m/%d}/{uuid.uuid4().hex}{ext.lower()}"
 
-class UploadRequest(models.Model):
-    OCCURRENCE = 'occurrence'
-    SPATIAL = 'spatial'
-    SPECIES_CHECKLIST_OR_TAXONOMIC_RESOURCE = 'species-checklist'
-    
-    TYPE_CHOICES = (
-        (OCCURRENCE, 'Occurrence Data'),
-        (SPATIAL, 'Spatial Layer'),
-        (SPECIES_CHECKLIST_OR_TAXONOMIC_RESOURCE, 'Species Checklist or Taxonomic Resource'),
+
+class UploadType(models.Model):
+    """Upload type model for categorizing upload requests"""
+    name = models.CharField(
+        max_length=255,
+        blank=False,
+        null=False,
+        help_text='Display name for the upload type'
+    )
+    code = models.CharField(
+        max_length=50,
+        unique=True,
+        blank=False,
+        null=False,
+        help_text='Unique identifier code (e.g., occurrence, spatial, species-checklist)'
+    )
+    description = models.TextField(
+        help_text='Optional description',
+        null=True,
+        blank=True
+    )
+    order = models.IntegerField(
+        default=0,
+        blank=False,
+        null=False,
+        help_text='Display order in forms'
     )
 
+    def __str__(self):
+        return self.name
+
+    class Meta:
+        ordering = ('order',)
+        verbose_name = 'Upload Type'
+        verbose_name_plural = 'Upload Types'
+
+
+class UploadRequest(models.Model):
     STATUS_SUBMITTED = 'submitted'
     STATUS_TICKETED = 'ticketed'
     STATUS_ERROR = 'error'
@@ -38,7 +65,12 @@ class UploadRequest(models.Model):
     title = models.CharField(max_length=255, blank=True, default='')
     name = models.CharField(max_length=255)
     email = models.EmailField()
-    upload_type = models.CharField(max_length=20, choices=TYPE_CHOICES)
+    upload_type = models.ForeignKey(
+        UploadType,
+        on_delete=models.PROTECT,
+        related_name='upload_requests',
+        help_text='Type of upload request'
+    )
     upload_file = models.FileField(upload_to=upload_path)
     notes = models.TextField(blank=True)
     source = models.CharField(max_length=255, blank=True)
@@ -53,7 +85,7 @@ class UploadRequest(models.Model):
         ordering = ('-created_at',)
 
     def __str__(self):
-        return f"{self.get_upload_type_display()} by {self.name} on {self.created_at:%Y-%m-%d}"
+        return f"{self.upload_type.name} by {self.name} on {self.created_at:%Y-%m-%d}"
 
     @property
     def file_name(self):

--- a/bims/static/js/uploader.js
+++ b/bims/static/js/uploader.js
@@ -3,7 +3,6 @@
         var val = $('#id_upload_type').val();
         var isSpatial = (val === 'spatial');
 
-        $('#spatial-notes-wrapper').toggleClass('d-none', !isSpatial);
         $('#upload-file-wrapper').toggleClass('d-none', val === '');
 
         $('[data-occurrence-label]').toggleClass('d-none', isSpatial);

--- a/bims/templates/uploader.html
+++ b/bims/templates/uploader.html
@@ -143,15 +143,13 @@
                         </label>
                         <select id="id_upload_type" name="upload_type" class="form-control" required>
                             <option value="">{% trans "Select an option" %}</option>
-                            <option value="occurrence" {% if form and form.data.upload_type == 'occurrence' %}selected{% endif %}>
-                                {% trans "Upload Occurrence Data" %}
-                            </option>
-                            <option value="spatial" {% if form and form.data.upload_type == 'spatial' %}selected{% endif %}>
-                                {% trans "Upload Spatial Layer" %}
-                            </option>
-                            <option value="species-checklist" {% if form and form.data.upload_type == 'species-checklist' %}selected{% endif %}>
-                                {% trans "Upload Species Checklist or Taxonomic Resource" %}
-                            </option>
+                            {% for choice_value, choice_label in form.upload_type.field.choices %}
+                                {% if choice_value %}
+                                    <option value="{{ choice_value }}" {% if form and form.data.upload_type == choice_value %}selected{% endif %}>
+                                        {{ choice_label }}
+                                    </option>
+                                {% endif %}
+                            {% endfor %}
                         </select>
                         {% if form and form.upload_type and form.upload_type.errors %}
                             <p class="help-block text-danger">{{ form.upload_type.errors|join:", " }}</p>
@@ -178,15 +176,15 @@
                         {% endif %}
                     </div>
 
-                    <div id="spatial-notes-wrapper" class="form-group d-none">
+                    <div class="form-group">
                         <label for="id_notes" class="control-label">
-                            {% trans "Notes (Spatial Layer)" %}
+                            {% trans "Notes" %}
                         </label>
                         <textarea id="id_notes"
                                   name="notes"
                                   rows="3"
                                   class="form-control"
-                                  placeholder="{% trans 'Any context about the layer (extent, scale, licensing, etc.)' %}"></textarea>
+                                  placeholder="{% trans 'Any additional context or information about the upload' %}"></textarea>
                         <p class="help-block">{% trans "Optional, but helpful to admins." %}</p>
                     </div>
 

--- a/bims/views/upload.py
+++ b/bims/views/upload.py
@@ -175,7 +175,7 @@ class UploadView(UserPassesTestMixin, FormView):
             f"**New Upload**\n\n"
             f"- **Name:** {instance.name}\n"
             f"- **Email:** {instance.email}\n"
-            f"- **Type:** {instance.get_upload_type_display()}\n"
+            f"- **Type:** {instance.upload_type.name}\n"
             f"- **Notes:** {instance.notes or '-'}\n"
             f"- **File:** [{instance.file_name}]({file_url})\n"
             f"- **Upload ID:** {instance.pk}\n"


### PR DESCRIPTION
Adds a new upload type for species checklists or taxonomic resources to the uploader, including the model choice and template option.

For https://github.com/kartoza/django-bims/issues/4856#issuecomment-3490106120