### PR TITLE
 Improve taxa management page with "all taxa" default view

### DIFF
--- a/bims/serializers/taxon_serializer.py
+++ b/bims/serializers/taxon_serializer.py
@@ -455,11 +455,15 @@ class TaxonSerializer(serializers.ModelSerializer):
                 'name': taxon_group.name
             }
         taxonomy_obj = self.taxonomy_obj(obj)
-        taxon_module = taxonomy_obj.taxongroup_set.first()
+        taxon_module = taxonomy_obj.taxongroup_set.filter(
+            category='SPECIES_MODULE', parent__isnull=True
+        ).first() or taxonomy_obj.taxongroup_set.filter(
+            category='SPECIES_MODULE'
+        ).first()
         if taxon_module:
             return {
                 'id': taxon_module.id,
-                'logo': taxon_module.logo.name,
+                'logo': taxon_module.logo.name if taxon_module.logo else '',
                 'name': taxon_module.name
             }
         return {}

--- a/bims/static/css/taxa_management.css
+++ b/bims/static/css/taxa_management.css
@@ -1,3 +1,51 @@
+a.badge-module {
+  background-color: #5a7fa8;
+  color: #fff !important;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+a.badge-module:hover {
+  background-color: #3f618a;
+  text-decoration: none;
+  color: #fff !important;
+}
+
+#active-filters-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-bottom: 8px;
+  min-height: 0;
+  position: absolute;
+  margin-left: 425px;
+}
+
+.active-filter-pill {
+  align-items: center;
+  gap: 4px;
+  background: #eef2f7;
+  border: 1px solid #ccd6e0;
+  border-radius: 20px;
+  padding: 2px 10px 2px 8px;
+  font-size: 0.72rem;
+  color: #3a3a3a;
+  white-space: nowrap;
+}
+
+.filter-pill-label {
+  font-weight: 600;
+  color: #555;
+  text-transform: uppercase;
+  font-size: 0.65rem;
+  letter-spacing: 0.04em;
+  margin-right: 2px;
+}
+
+.filter-pill-label::after {
+  content: ':';
+}
+
 .total-data {
     color: #444444;
     border-radius: 10px;

--- a/bims/static/js/taxa_management/taxa_sidebar.js
+++ b/bims/static/js/taxa_management/taxa_sidebar.js
@@ -140,15 +140,26 @@ export const taxaSidebar = (() => {
             currentTry++;
             $elm = $elm.parent();
         }
-        $('.ui-state-default').removeClass('selected');
-        $elm.addClass('selected');
-        if (updateTaxonGroup) {
-            updateTaxonGroup($elm.data('id'));
-        }
-        selectedTaxonGroup = $elm.data('id');
-        $('.dashboard-title').html(`<h2>${$elm.data('name')}</h2>`);
-        currentSelectedTaxonGroup = selectedTaxonGroup;
 
+        if ($elm.hasClass('selected')) {
+            // Deselect current group
+            $elm.removeClass('selected');
+            selectedTaxonGroup = '';
+            currentSelectedTaxonGroup = '';
+            $('.dashboard-title').html('<h2>Taxon Management</h2>');
+            if (updateTaxonGroup) {
+                updateTaxonGroup('');
+            }
+        } else {
+            $('.ui-state-default').removeClass('selected');
+            $elm.addClass('selected');
+            selectedTaxonGroup = $elm.data('id');
+            currentSelectedTaxonGroup = selectedTaxonGroup;
+            $('.dashboard-title').html(`<h2>${$elm.data('name')}</h2>`);
+            if (updateTaxonGroup) {
+                updateTaxonGroup($elm.data('id'));
+            }
+        }
     }
 
     function allTaxaGroups(groups) {

--- a/bims/static/js/taxa_management/taxa_table.js
+++ b/bims/static/js/taxa_management/taxa_table.js
@@ -11,6 +11,22 @@ export const taxaTable = (() => {
     let url = '';
     let selectedTaxonGroup = '';
 
+    const FILTER_LABELS = {
+        ranks:             'Rank',
+        origins:           'Origin',
+        tags:              'Tags',
+        bD:                'Biogeographic dist.',
+        author:            'Author',
+        endemism:          'Endemism',
+        taxonomic_status:  'Tax. status',
+        cons_status:       'Cons. status',
+        validated:         'Validated',
+        family:            'Family',
+        genus:             'Genus',
+        species:           'Species',
+        parent:            'Parent taxon',
+    };
+
     function convertAuthorStringToArray(authorString) {
         authorString = decodeURIComponent(authorString)
         // Split the string by comma between quotes
@@ -133,52 +149,43 @@ export const taxaTable = (() => {
 
     function handleUrlParameters() {
         let taxonName = '';
+        url = '/api/taxa-list/?';
         if (currentSelectedTaxonGroup) {
             $('#sortable').find(`[data-id="${currentSelectedTaxonGroup}"]`).addClass('selected');
-            url = `/api/taxa-list/?taxonGroup=${currentSelectedTaxonGroup}`
+            url += `taxonGroup=${currentSelectedTaxonGroup}`;
         }
 
         let validated = 'True'
         if (urlParams.get('validated')) {
             validated = urlParams.get('validated');
         }
-        if (url) {
-            url += `&validated=${validated}`;
-        }
+        url += `&validated=${validated}`;
         $(`input[name="validated"][value="${validated}"]`).prop('checked', true);
 
         let tagFilterType = 'OR';
         if (urlParams.get('tagFT')) {
             tagFilterType = urlParams.get('tagFT');
         }
-        if (url) {
-            url += `&tagFT=${tagFilterType}`;
-        }
+        url += `&tagFT=${tagFilterType}`;
         $(`input[name="tag-filter-type"][value="${tagFilterType}"]`).prop('checked', true);
 
         let bDFilterType = 'OR';
         if (urlParams.get('bDFT')) {
             bDFilterType = urlParams.get('bDFT');
         }
-        if (url) {
-            url += `&bDFT=${bDFilterType}`;
-        }
+        url += `&bDFT=${bDFilterType}`;
         $(`input[name="biographic-distributions-filter-type"][value="${bDFilterType}"]`).prop('checked', true);
 
         if (urlParams.get('taxon')) {
             taxonName = urlParams.get('taxon');
-            if (url) {
-                url += `&taxon=${taxonName}`
-                $('#taxon-name-input').val(taxonName)
-                $clearSearchBtn.show();
-            }
+            url += `&taxon=${taxonName}`;
+            $('#taxon-name-input').val(taxonName);
+            $clearSearchBtn.show();
         }
         if (urlParams.get('o')) {
             const order = urlParams.get('o');
-            if (url) {
-                $(`.sort-button[data-order="${order}"]`).addClass('sort-button-selected');
-                url += `&o=${order}`
-            }
+            $(`.sort-button[data-order="${order}"]`).addClass('sort-button-selected');
+            url += `&o=${order}`;
         }
         if (urlParams.get('page')) {
             url += `&page=${urlParams.get('page')}`;
@@ -344,6 +351,7 @@ export const taxaTable = (() => {
             $clearSearchBtn.show();
             $('#total-selected-filter').html(totalAllFilters);
         }
+        renderActiveFilters();
     }
 
     function handleFilters(event) {
@@ -419,6 +427,44 @@ export const taxaTable = (() => {
         }
         urlParams = insertParam('taxon', '', true, false, urlParams);
         document.location.search = urlParams;
+    }
+
+    function renderActiveFilters() {
+        const $container = $('#active-filters-container');
+        $container.empty();
+
+        const taxonSearch = $('#taxon-name-input').val();
+        if (taxonSearch) {
+            $container.append(
+                `<span class="active-filter-pill"><span class="filter-pill-label">Search</span>${taxonSearch}</span>`
+            );
+        }
+
+        $.each(filterSelected, function (key, value) {
+            const label = FILTER_LABELS[key] || key;
+            let displayValue;
+            if (key === 'validated') {
+                displayValue = 'Unvalidated';
+            } else if (Array.isArray(value)) {
+                displayValue = value.join(', ');
+            } else {
+                displayValue = value;
+            }
+            $container.append(
+                `<span class="active-filter-pill"><span class="filter-pill-label">${label}</span>${displayValue}</span>`
+            );
+        });
+    }
+
+    function removeValidatedFilter() {
+        if (!filterSelected['validated']) return;
+        delete filterSelected['validated'];
+        totalAllFilters = Math.max(0, totalAllFilters - 1);
+        $('#total-selected-filter').html(totalAllFilters || '');
+        if (Object.keys(filterSelected).length === 0) {
+            $clearSearchBtn.hide();
+        }
+        renderActiveFilters();
     }
 
     function handleSearch(event) {
@@ -532,6 +578,8 @@ export const taxaTable = (() => {
         init,
         handleRemoveTaxonFromGroup,
         handleRejectTaxon,
-        handleValidateTaxon
+        handleValidateTaxon,
+        removeValidatedFilter,
+        renderActiveFilters
     };
 })();

--- a/bims/templates/taxa_management.html
+++ b/bims/templates/taxa_management.html
@@ -90,6 +90,8 @@
                         </button>
                     </div>
 
+                    <div id="active-filters-container"></div>
+
                     <div class="row" style="font-size: 0.9em;">
                         <div class="col-md-6">
                             <div class="collapse" id="collapseFilter"  style="width: 100%; position: absolute;">
@@ -195,7 +197,7 @@
                                                 </div>
                                             </div>
                                             {% endif %}
-                                            <div class="form-group row">
+                                            <div class="form-group row" id="validated-filter-row" style="display:none">
                                                 <label for="validated" class="col-sm-3 col-form-label">Validated</label>
                                                 <div class="col-sm-9 d-flex">
                                                     <div class="form-check form-check-inline">

--- a/bims/views/download_csv_taxa_list.py
+++ b/bims/views/download_csv_taxa_list.py
@@ -318,18 +318,25 @@ def download_taxa_list(request):
 
     output = request.GET.get('output', 'csv')
 
-    taxon_group_id = request.GET.get('taxonGroup')
+    taxon_group_id = request.GET.get('taxonGroup', '')
     download_request_id = request.GET.get('downloadRequestId', '')
-    taxon_group = TaxonGroup.objects.get(
-        id=taxon_group_id
-    )
+
+    if taxon_group_id:
+        try:
+            taxon_group = TaxonGroup.objects.get(id=taxon_group_id)
+            group_label = taxon_group.name
+        except TaxonGroup.DoesNotExist:
+            taxon_group_id = ''
+            group_label = 'All_Taxa'
+    else:
+        group_label = 'All_Taxa'
 
     current_time = datetime.datetime.now()
     filter_hash = hash(json.dumps(request.GET.dict()))
 
     # Check if the file exists in the processed directory
     filename = (
-        f'{taxon_group.name}-{current_time.year}-'
+        f'{group_label}-{current_time.year}-'
         f'{current_time.month}-{current_time.day}-'
         f'{current_time.hour}-{filter_hash}'
     ).replace(' ', '_')

--- a/bims/views/taxa_management.py
+++ b/bims/views/taxa_management.py
@@ -61,11 +61,6 @@ class TaxaManagementView(LoginRequiredMixin, TemplateView):
             except TaxonGroup.DoesNotExist:
                 pass
 
-        if not context['selected_taxon_group']:
-            context['selected_taxon_group'] = TaxonGroup.objects.filter(
-                category='SPECIES_MODULE',
-            ).first()
-
         context['taxa_groups_json'] = json.dumps(context['taxa_groups'])
         context['taxon_rank'] = [
             rank.name for rank in TaxonomicRank


### PR DESCRIPTION
  - Default to no taxon group selected on page load, showing all validated taxa across all SPECIES_MODULE groups
  - Show module badge (with link) under taxon name when no group is selected
  - Add active filter pills container showing current filters with refined labels
  - Validated filter row is hidden when no group is selected; shown on select
  - Add drag handle for taxon group reordering (change_taxongroup permission)
  - Constrain sortable to vertical axis; use thin placeholder line on drag
  - Fix stale data after group switch by using URLSearchParams.set instead of regex replace for taxonGroup param
  - Fix pagination button highlight mismatch
  - Reset page to 0 when switching or deselecting taxon group
  - Update TaxaList API to scope to all SPECIES_MODULE groups when no group given; force validated=True for ungrouped queries
  - Fix download_taxa_list view to support download without taxon group